### PR TITLE
updated maven repository to use SSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <repository>
             <id>central</id>
             <name>central</name>
-            <url>http://central.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The install instructions
`mvn clean install -DskipTests`
didn't work because of a wrong repository address.

`[ERROR] Failed to execute goal on project kafka-connect-hana: Could not resolve dependencies for project com.sap:kafka-connect-hana:jar:1.0-SNAPSHOT: Failed to collect dependencies at org.scala-lang:scala-library:jar:2.12.11: Failed to read artifact descriptor for org.scala-lang:scala-library:jar:2.12.11: Could not transfer artifact org.scala-lang:scala-library:pom:2.12.11 from/to central (http://central.maven.org/maven2/): Transfer failed for http://central.maven.org/maven2/org/scala-lang/scala-library/2.12.11/scala-library-2.12.11.pom: Unknown host central.maven.org: nodename nor servname provided, or not known -> [Help 1]`