### PR TITLE
updated repository url to use SSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <repository>
             <id>central</id>
             <name>central</name>
-            <url>http://central.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Install instructions `mvn clean install -DskipTests` didn't work because the maven repository wasn't reachable under the provided repository URL without SSL.