### PR TITLE
make autcommit false by default; release the unused connections durin…

### DIFF
--- a/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
@@ -71,7 +71,9 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
        Class.forName(driver)
        Try(DriverManager.getConnection(jdbcUrl, connectionUser, connectionPassword))
        match {
-         case Success(conn) => conn
+         case Success(conn) =>
+           conn.setAutoCommit(false)
+           conn
          case Failure(ex) if isFailedToOpenConnectionException(ex) =>
            throw new HANAJdbcConnectionException(s"Opening a connection failed")
          case Failure(ex) =>
@@ -201,7 +203,6 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
       log.info(s"Creating collection:$collectionName with SQL: $query")
 
       val connection = getConnection
-      connection.setAutoCommit(false)
       val stmt = connection.createStatement()
       Try(stmt.execute(query)) match {
         case Failure(ex) => log.error("Error during collection creation", ex)

--- a/src/main/scala/com/sap/kafka/connect/sink/hana/HANAWriter.scala
+++ b/src/main/scala/com/sap/kafka/connect/sink/hana/HANAWriter.scala
@@ -22,15 +22,12 @@ class HANAWriter(config: HANAConfig, hanaClient: HANAJdbcClient,
   private var connection:Connection = null
 
   override def initializeConnection(): Unit = {
+    if (connection != null && !connection.isValid(120)) {
+      connection.close()
+    }
     if(connection == null || connection.isClosed ) {
       connection = hanaClient.getConnection
     }
-    else if(!connection.isValid(120))
-    {
-      connection.close()
-      connection = hanaClient.getConnection
-    }
-    connection.setAutoCommit(false)
   }
 
 


### PR DESCRIPTION
…g tests (#19)

I think it is easier to be able to assume the connection is autoCommit=false independently of the setting given by the connection url.
This change make the connection retrieved from getConnection() is autoCommit=false.
And some test code have been adjusted for this change as the code assume autoCommit=true.