### PR TITLE
fix date/time related issues

### DIFF
--- a/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
@@ -1,6 +1,7 @@
 package com.sap.kafka.client.hana
 
 import java.sql.{Connection, DriverManager, ResultSet}
+import java.util.{Calendar, TimeZone}
 
 import com.sap.kafka.client.{ColumnRow, MetaSchema, hana, metaAttr}
 import com.sap.kafka.connect.config.hana.HANAConfig
@@ -19,6 +20,8 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
   protected val driver: String = "com.sap.db.jdbc.Driver"
 
   private val CONNECTION_FAIL_R = ".*Failed to open connection.*".r
+
+  private val calendarUTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
 
   /**
    * Checks whether the provided exception is a connection opening failure one.
@@ -475,9 +478,9 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
 
       case java.sql.Types.DOUBLE => resultSet.getDouble(index)
 
-      case java.sql.Types.DATE => resultSet.getDate(index)
-      case java.sql.Types.TIME => resultSet.getTime(index)
-      case java.sql.Types.TIMESTAMP => resultSet.getTimestamp(index)
+      case java.sql.Types.DATE => resultSet.getDate(index, calendarUTC)
+      case java.sql.Types.TIME => resultSet.getTime(index, calendarUTC)
+      case java.sql.Types.TIMESTAMP => resultSet.getTimestamp(index, calendarUTC)
 
       case java.sql.Types.NCLOB | java.sql.Types.CLOB => resultSet.getString(index)
 

--- a/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
+++ b/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
@@ -82,42 +82,22 @@ trait GenericJdbcTypeConverter {
       stmt.setBytes(i + 1, value.asInstanceOf[Array[Byte]])
     case java.sql.Types.DATE => (value: Any) => stmt.setDate(i + 1, convertToJdbcDateTypeFromAvroDateType(value))
     case java.sql.Types.TIME => (value: Any) => stmt.setTime(i + 1, convertToJdbcTimeTypeFromAvroTimeType(value))
-    case java.sql.Types.TIMESTAMP => (value: Any) => stmt.setTimestamp(i + 1, convertToJdbcTypeFromAvroTimestampType(value))
+    case java.sql.Types.TIMESTAMP => (value: Any) => stmt.setTimestamp(i + 1, convertToJdbcTimesampTypeFromAvroTimestampType(value))
     case other =>
       (value: Any) =>
         sys.error(s"Unable to translate the non-null value for the field $i")
   }})
 
   private def convertToJdbcDateTypeFromAvroDateType(value: Any): java.sql.Date = {
-    val avroDateParser = new SimpleDateFormat("E MMM dd HH:mm:ss Z yyyy")
-
-    new java.sql.Date(avroDateParser.parse(value.toString).getTime)
+    new java.sql.Date(value.asInstanceOf[java.util.Date].getTime)
   }
 
   private def convertToJdbcTimeTypeFromAvroTimeType(value: Any): java.sql.Time = {
-    try {
-      val avroTimeParser = new SimpleDateFormat("E MMM dd HH:mm:ss.SSS Z yyyy")
-
-      new java.sql.Time(avroTimeParser.parse(value.toString).getTime)
-    } catch {
-      case e: Exception =>
-        val avroTimeParser = new SimpleDateFormat("E MMM dd HH:mm:ss Z yyyy")
-
-        new java.sql.Time(avroTimeParser.parse(value.toString).getTime)
-    }
+    new java.sql.Time(value.asInstanceOf[java.util.Date].getTime)
   }
 
-  private def convertToJdbcTypeFromAvroTimestampType(value: Any): java.sql.Timestamp = {
-    try {
-      val avroTimestampParser = new SimpleDateFormat("E MMM dd HH:mm:ss.SSS Z yyyy")
-
-      new java.sql.Timestamp(avroTimestampParser.parse(value.toString).getTime)
-    } catch {
-      case e: Exception =>
-        val avroTimestampParser = new SimpleDateFormat("E MMM dd HH:mm:ss Z yyyy")
-
-        new java.sql.Timestamp(avroTimestampParser.parse(value.toString).getTime)
-    }
+  private def convertToJdbcTimesampTypeFromAvroTimestampType(value: Any): java.sql.Timestamp = {
+    new java.sql.Timestamp(value.asInstanceOf[java.util.Date].getTime)
   }
 
   /**

--- a/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
@@ -2,7 +2,8 @@ package com.sap.kafka.connect.sink
 
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
-import java.util
+import java.{sql, util}
+import java.util.TimeZone
 
 import com.sap.kafka.connect.MockJdbcClient
 import com.sap.kafka.connect.config.hana.HANAParameters
@@ -112,7 +113,6 @@ class AvroLogicalTypesTest extends FunSuite {
     val expectedTimeField = "02:02:02"
     val date = simpleDateFormat.parse(expectedDateField)
 
-
     val struct = new Struct(schema).put("time_field", date)
 
     task.put(util.Collections.singleton(
@@ -124,8 +124,9 @@ class AvroLogicalTypesTest extends FunSuite {
     val structs = rs.get
     assert(structs.size === 1)
     val head = structs.head
-
-    val actualDateField = head.get("time_field").toString
+    val simpleTimeFormat = new SimpleDateFormat("hh:mm:ss")
+    simpleTimeFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+    val actualDateField = simpleTimeFormat.format(head.get("time_field"))
     assert(expectedTimeField === actualDateField)
   }
 
@@ -166,10 +167,8 @@ class AvroLogicalTypesTest extends FunSuite {
     // }
     val simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'")
     val expectedDateField = "2013-10-16T02:02:02.002Z"
-    val expectedTimestampField = "2013-10-16 02:02:02.0"
+    val expectedTimestampField = "2013-10-16 02:02:02.002"
     val date = simpleDateFormat.parse(expectedDateField)
-
-
     val struct = new Struct(schema).put("timestamp_field", date)
 
     task.put(util.Collections.singleton(
@@ -182,7 +181,9 @@ class AvroLogicalTypesTest extends FunSuite {
     assert(structs.size === 1)
     val head = structs.head
 
-    val actualDateField = head.get("timestamp_field").toString
+    val simpleTimestampFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS")
+    simpleTimestampFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+    val actualDateField = simpleTimestampFormat.format(head.get("timestamp_field"))
     assert(expectedTimestampField === actualDateField)
   }
 


### PR DESCRIPTION
This PR fixes two date/time related issues.
1. java.util.Date is instantiated with the local time zone and this may result in a Date instance with a non-hour value or the wrong date value. It may be unnoticed or results in the error.
```
Caused by: org.apache.kafka.connect.errors.DataException: Kafka Connect Date type should not have any time fields set to non-zero values.
	at org.apache.kafka.connect.data.Date.fromLogical(Date.java:64)
	at io.confluent.connect.avro.AvroData$6.convert(AvroData.java:281)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:425)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:612)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:371)
	at io.confluent.connect.avro.AvroConverter.fromConnectData(AvroConverter.java:80)
	at org.apache.kafka.connect.storage.Converter.fromConnectData(Converter.java:62)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.lambda$convertTransformedRecord$2(WorkerSourceTask.java:290)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:128)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:162)
	... 11 more
```

2. sql.Timestamp is instantiated at `GenericJdbcTypeConverter.convertToJdbcTimeTypeFromAvroTimeType` from the default string representation of avro date and not directly from its internal representation. As a result, the sub-seconds are dropped.

