### PR TITLE
Allow string types for incrementing mode usage; fix duplicated type typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ from where clause in query sql.
   * `{topic}.poll.interval.ms` - This setting allows specifying the poll interval at which the data should be fetched from SAP DB table. Should be an `Integer`. Default value is `60000`.
 
   * `{topic}.incrementing.column.name` - In order to fetch data from a SAP DB table when `mode` is set to `incrementing`, an incremental ( or auto-incremental ) column needs to be provided. The type 
-of the column can be `Int, Float, Decimal, Timestamp`. This considers SAP DB Timeseries tables also. Should be a valid clumn name ( respresented as a `String`) present in the table. 
+of the column can be numeric types such as `INTEGER`, `FLOAT`, `DECIMAL`, datetime types such as `DATE`, `TIME`, `TIMESTAMP`, and character types `VARCHAR`, `NVARCHAR` containing alpha-numeric characters. This considers SAP DB Timeseries tables also. Should be a valid column name ( respresented as a `String`) present in the table. See [data types in SAP HANA](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/LATEST/en-US/20a1569875191014b507cf392724b7eb.html)
  
   * `{topic}.partition.count` - This setting can be used to specify the no. of topic partitions that the Source connector can use to publish the data. Should be an `Integer`. Default value is `1`.
 

--- a/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
@@ -454,7 +454,7 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
   private def getColumnData(columnType: Int, resultSet: ResultSet, index: Int) = {
     val value = columnType match {
       case java.sql.Types.VARCHAR | java.sql.Types.NVARCHAR |
-        java.sql.Types.NCHAR | java.sql.Types.CHAR | java.sql.Types.LONGNVARCHAR
+        java.sql.Types.NCHAR | java.sql.Types.CHAR | java.sql.Types.LONGVARCHAR
         | java.sql.Types.LONGNVARCHAR => resultSet.getString(index)
 
       case java.sql.Types.BOOLEAN => resultSet.getBoolean(index)

--- a/src/main/scala/com/sap/kafka/connect/source/querier/IncrColTableQuerier.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/querier/IncrColTableQuerier.scala
@@ -89,22 +89,17 @@ class IncrColTableQuerier(mode: String, tableOrQuery: String, tablePartition: In
 
     metadata.foreach(metaAttr => {
       if (metaAttr.name.equals(incrementingCol)) {
-        if (metaAttr.dataType == java.sql.Types.INTEGER ||
-          metaAttr.dataType == java.sql.Types.BIGINT ||
-          metaAttr.dataType == java.sql.Types.FLOAT ||
-          metaAttr.dataType == java.sql.Types.DOUBLE ||
-          metaAttr.dataType == java.sql.Types.DECIMAL ||
-          metaAttr.dataType == java.sql.Types.REAL ||
-          metaAttr.dataType == java.sql.Types.DATE ||
-          metaAttr.dataType == java.sql.Types.TIME ||
-          metaAttr.dataType == java.sql.Types.TIMESTAMP) {
-          incrColumnType = metaAttr.dataType
-          return metaAttr.name
+        metaAttr.dataType match {
+          case java.sql.Types.INTEGER | java.sql.Types.BIGINT | java.sql.Types.FLOAT | java.sql.Types.DOUBLE | java.sql.Types.REAL |
+               java.sql.Types.DATE | java.sql.Types.TIME | java.sql.Types.TIMESTAMP |
+               java.sql.Types.VARCHAR | java.sql.Types.NVARCHAR | java.sql.Types.CHAR | java.sql.Types.NCHAR =>
+            incrColumnType = metaAttr.dataType
+            return metaAttr.name
         }
       }
     })
     throw new IllegalArgumentException("The Incrementing column is not found in the " +
-      "table or is not of correct type")
+      "table or is not of supported type")
   }
 
   /**

--- a/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
+++ b/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
@@ -170,7 +170,7 @@ trait GenericJdbcTypeConverter {
         if (optional)
           fieldBuilder.optional()
         builder.field(fieldname, fieldBuilder.build())
-      case java.sql.Types.CHAR | java.sql.Types.VARCHAR | java.sql.Types.LONGNVARCHAR |
+      case java.sql.Types.CHAR | java.sql.Types.VARCHAR | java.sql.Types.LONGVARCHAR |
            java.sql.Types.NCHAR | java.sql.Types.NVARCHAR | java.sql.Types.LONGNVARCHAR |
            java.sql.Types.CLOB | java.sql.Types.NCLOB | java.sql.Types.DATALINK |
            java.sql.Types.SQLXML =>

--- a/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskTestBase.scala
+++ b/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskTestBase.scala
@@ -20,6 +20,7 @@ class HANASourceTaskTestBase extends FunSuite
   protected val SINGLE_TABLE_NAME_FOR_BULK_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE\""
 
   protected val SINGLE_TABLE_NAME_FOR_INCR_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_INCR_LOAD\""
+  protected val SINGLE_TABLE_NAME_FOR_INCR2_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_INCR2_LOAD\""
 
   protected val FIRST_TABLE_NAME_FOR_MULTI_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_MULTI_LOAD\""
   protected val SECOND_TABLE_NAME_FOR_MULTI_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_SECOND_FOR_MULTI_LOAD\""
@@ -28,6 +29,8 @@ class HANASourceTaskTestBase extends FunSuite
   SINGLE_TABLE_PARTITION_FOR_BULK_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_BULK_LOAD + "_0")
   protected val SINGLE_TABLE_PARTITION_FOR_INCR_LOAD = new util.HashMap[String, String]()
   SINGLE_TABLE_PARTITION_FOR_INCR_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_INCR_LOAD + "_0")
+  protected val SINGLE_TABLE_PARTITION_FOR_INCR2_LOAD = new util.HashMap[String, String]()
+  SINGLE_TABLE_PARTITION_FOR_INCR2_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_INCR2_LOAD + "_0")
   protected val FIRST_TABLE_PARTITION_FOR_MULTI_LOAD = new util.HashMap[String, String]()
   FIRST_TABLE_PARTITION_FOR_MULTI_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, FIRST_TABLE_NAME_FOR_MULTI_LOAD + "_0")
   protected val SECOND_TABLE_PARTITION_FOR_MULTI_LOAD = new util.HashMap[String, String]()
@@ -56,6 +59,7 @@ class HANASourceTaskTestBase extends FunSuite
       val partitions = new util.HashMap[String, String]()
       partitions.putAll(SINGLE_TABLE_PARTITION_FOR_BULK_LOAD)
       partitions.putAll(SINGLE_TABLE_PARTITION_FOR_INCR_LOAD)
+      partitions.putAll(SINGLE_TABLE_PARTITION_FOR_INCR2_LOAD)
       partitions.putAll(FIRST_TABLE_PARTITION_FOR_MULTI_LOAD)
       partitions.putAll(SECOND_TABLE_PARTITION_FOR_MULTI_LOAD)
 


### PR DESCRIPTION
This is a workaround patch to support pseudo date types such as AEDAT and other character based alpha-numeric values as the incrementing column.
It basically allows those character based types but the value must only consist of alpha-numeric characters and the common date/time delimiter characters ':', '-', ' '.

This should resolve https://github.com/SAP/kafka-connect-sap/issues/41