### PR TITLE
update pom and eliminate some warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,21 +7,20 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <mockito-all.version>1.10.19</mockito-all.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <encoding>UTF-8</encoding>
+
+        <guava.version>19.0</guava.version>
+        <mockito-core.version>3.6.0</mockito-core.version>
         <kafka.version>2.4.1</kafka.version>
         <scala.version>2.12.11</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scalatest.version>3.1.2</scalatest.version>
+        <slf4j.version>1.7.21</slf4j.version>
     </properties>
 
     <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
         <repository>
             <id>central</id>
             <name>central</name>
@@ -55,8 +54,9 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>${guava.version}</version>
         </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>com.h2database</groupId>
@@ -66,14 +66,20 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito-all.version}</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -100,8 +106,9 @@
         <plugins>
             <!-- maven scala plugin -->
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.3.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskTestBase.scala
+++ b/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskTestBase.scala
@@ -13,7 +13,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.mockito.Mockito.mock
 import org.mockito.Mockito._
 import org.apache.kafka.connect.data.{Field, Schema}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 
 class HANASourceTaskTestBase extends FunSuite
                               with BeforeAndAfterAll {


### PR DESCRIPTION
update pom.xml to eliminate the warning
```
HANASourceTaskTestBase:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
HANASourceTaskConversionTest:
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.mockito.cglib.core.ReflectUtils$2 (file:..../maven/repos/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.mockito.cglib.core.ReflectUtils$2
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
