### PR TITLE
Some Sink fixes - align the char-limit with that of HANA; fix the handling of keySchema at create table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
 
         <!-- test dependencies -->
         <dependency>
+            <groupId>com.sap.cloud.db.jdbc</groupId>
+            <artifactId>ngdbc</artifactId>
+            <version>2.5.49</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.192</version>
@@ -140,7 +146,18 @@
                     </args>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- maven shade plugin to bundle the jdbc driver -->
             <!--plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/scala/com/sap/kafka/client/hana/AbstractHANAPartitionLoader.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/AbstractHANAPartitionLoader.scala
@@ -1,7 +1,7 @@
 package com.sap.kafka.client.hana
 
 
-import java.sql.Connection
+import java.sql.{Connection, PreparedStatement}
 import java.util.function.Consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -43,8 +43,7 @@ trait AbstractHANAPartitionLoader {
                                     iterator: Iterator[SinkRecord],
                                     metaSchema: MetaSchema,
                                     batchSize: Int): Unit = {
-      WithCloseables(connection
-        .prepareStatement(prepareInsertIntoStmt(tableName, metaSchema))) { stmt =>
+    WithCloseables(connection.prepareStatement(prepareInsertIntoStmt(tableName, metaSchema))) { stmt =>
         val fieldsValuesConverters = HANAJdbcTypeConverter.getSinkRowDatatypesSetters(metaSchema.fields,
           stmt)
         for (batchRows <- iterator.grouped(batchSize)) {

--- a/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
@@ -1,6 +1,6 @@
 package com.sap.kafka.client.hana
 
-import java.sql.{Connection, DriverManager, ResultSet}
+import java.sql.{Connection, Driver, DriverManager, ResultSet}
 import java.util.{Calendar, TimeZone}
 
 import com.sap.kafka.client.{ColumnRow, MetaSchema, hana, metaAttr}
@@ -174,16 +174,17 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
           throw new HANAJdbcException("Hash Partition is not supported when keys are" +
             " not specified. Provide the 'pk.mode' parameter")
         } else {
-          partition = "PARTITION BY HASH(\"" + keys.mkString("\", \"") + "\") PARTITIONS " + partitionCount
+          partition = " PARTITION BY HASH(\"" + keys.mkString("\", \"") + "\") PARTITIONS " + partitionCount
         }
       } else if (partitionType == BaseConfigConstants.ROUND_ROBIN_PARTITION) {
-        partition = "PARTITION BY ROUNDROBIN PARTITIONS " + partitionCount
+        partition = " PARTITION BY ROUNDROBIN PARTITIONS " + partitionCount
       }
 
       val query = if (columnTable)
-        s"""CREATE COLUMN TABLE $fullTableName ($fixedSchema$primaryKeys) $partition"""
+        s"""CREATE COLUMN TABLE $fullTableName ($fixedSchema$primaryKeys)$partition"""
       else
-        s"""CREATE TABLE $fullTableName ($fixedSchema$primaryKeys) $partition"""
+        s"""CREATE TABLE $fullTableName ($fixedSchema$primaryKeys)$partition"""
+
       log.info(s"Creating table:$tableName with SQL: $query")
       val connection = getConnection
       val stmt = connection.createStatement()

--- a/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkRecordsCollector.scala
+++ b/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkRecordsCollector.scala
@@ -53,15 +53,16 @@ class HANASinkRecordsCollector(var tableName: String, client: HANAJdbcClient,
       case true =>
         log.info(s"""Table $tableName exists.Validate the schema and check if schema needs to evolve""")
         var recordFields = Seq[metaAttr]()
-
-        if (recordSchema.keySchema != null) {
-          for (field <- recordSchema.keySchema.fields) {
-            val fieldSchema: Schema = field.schema()
-            val fieldAttr = metaAttr(field.name(),
-              HANAJdbcTypeConverter.convertToHANAType(fieldSchema), 1, 0, 0, isSigned = false)
-            recordFields = recordFields :+ fieldAttr
-          }
-        }
+        //REVISIT we should cache keySchema and valueSchema at the collector to perform a quick comparison
+        // we build recordFields for valueSchema to compare it against metaSchema retrieved from the table
+//        if (recordSchema.keySchema != null) {
+//          for (field <- recordSchema.keySchema.fields) {
+//            val fieldSchema: Schema = field.schema()
+//            val fieldAttr = metaAttr(field.name(),
+//              HANAJdbcTypeConverter.convertToHANAType(fieldSchema), 1, 0, 0, isSigned = false)
+//            recordFields = recordFields :+ fieldAttr
+//          }
+//        }
 
         if (recordSchema.valueSchema != null) {
           for (field <- recordSchema.valueSchema.fields) {
@@ -72,7 +73,8 @@ class HANASinkRecordsCollector(var tableName: String, client: HANAJdbcClient,
           }
         }
         if(config.topicProperties(recordHead.topic())("table.type") != BaseConfigConstants.COLLECTION_TABLE_TYPE
-            && !compareSchema(recordFields))
+          //REVISIT couldn't we just use !java.util.Objects.equals(metaSchema, recordFields)?
+          && !compareSchema(recordFields))
           {
             log.error(
               s"""Table $tableName has a different schema from the record Schema.
@@ -100,15 +102,15 @@ class HANASinkRecordsCollector(var tableName: String, client: HANAJdbcClient,
 
           metaSchema = new MetaSchema(Seq[metaAttr](), Seq[Field]())
 
-          if (recordSchema.keySchema != null) {
-            for (field <- recordSchema.keySchema.fields) {
-              val fieldSchema: Schema = field.schema
-              val fieldAttr = metaAttr(field.name(),
-                HANAJdbcTypeConverter.convertToHANAType(fieldSchema), 1, 0, 0, isSigned = false)
-              metaSchema.fields = metaSchema.fields :+ fieldAttr
-              metaSchema.avroFields = metaSchema.avroFields :+ field
-            }
-          }
+//          if (recordSchema.keySchema != null) {
+//            for (field <- recordSchema.keySchema.fields) {
+//              val fieldSchema: Schema = field.schema
+//              val fieldAttr = metaAttr(field.name(),
+//                HANAJdbcTypeConverter.convertToHANAType(fieldSchema), 1, 0, 0, isSigned = false)
+//              metaSchema.fields = metaSchema.fields :+ fieldAttr
+//              metaSchema.avroFields = metaSchema.avroFields :+ field
+//            }
+//          }
 
           if (recordSchema.valueSchema != null) {
             for (field <- recordSchema.valueSchema.fields) {

--- a/src/test/scala/com/sap/kafka/connect/MockJdbcDriver.scala
+++ b/src/test/scala/com/sap/kafka/connect/MockJdbcDriver.scala
@@ -1,0 +1,35 @@
+package com.sap.kafka.connect
+
+import java.sql.{Connection, Driver, DriverPropertyInfo}
+import java.util.Properties
+import java.util.logging.Logger
+
+class MockJdbcDriver(delegate: Driver) extends Driver {
+  override def connect(url: String, info: Properties): Connection = {
+    return delegate.connect(url, info)
+  }
+
+  override def acceptsURL(url: String): Boolean = {
+    return delegate.acceptsURL(url)
+  }
+
+  override def getPropertyInfo(url: String, info: Properties): Array[DriverPropertyInfo] = {
+    return delegate.getPropertyInfo(url, info)
+  }
+
+  override def getMajorVersion: Int = {
+    delegate.getMajorVersion
+  }
+
+  override def getMinorVersion: Int = {
+    delegate.getMinorVersion
+  }
+
+  override def jdbcCompliant(): Boolean = {
+    return delegate.jdbcCompliant
+  }
+
+  override def getParentLogger: Logger = {
+    return delegate.getParentLogger
+  }
+}

--- a/src/test/scala/com/sap/kafka/connect/sink/HANASinkTaskTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/sink/HANASinkTaskTest.scala
@@ -1,0 +1,112 @@
+package com.sap.kafka.connect.sink
+
+import java.sql.{Connection, DatabaseMetaData, Driver, DriverAction, DriverManager, DriverPropertyInfo, PreparedStatement, ResultSet, ResultSetMetaData, Statement, Types}
+import java.util
+import java.util.Collections
+
+import com.sap.kafka.connect.MockJdbcDriver
+import com.sap.kafka.connect.sink.hana.HANASinkTask
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+class HANASinkTaskTest extends FunSuite with BeforeAndAfterAll {
+  private val TEST_CONNECTION_URL= s"jdbc:sapmock://demo.hana.sap.com:50000/"
+  private val TOPIC = "test-topic"
+  private val SINGLE_TABLE_NAME_FOR_INSERT = "\"TEST\".\"EMPLOYEES_SINK\""
+
+  private var namedDriver: Driver = _
+  private var mockDriver: Driver = _
+  private var mockTaskContext: SinkTaskContext = _
+  private var mockConnection: Connection = _
+  private var mockStatement: Statement = _
+  private var mockPreparedStatement: PreparedStatement = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    mockDriver = mock(classOf[Driver])
+    when(mockDriver.acceptsURL(TEST_CONNECTION_URL)).thenReturn(true)
+    when(mockDriver.getMajorVersion()).thenReturn(1)
+
+    namedDriver = new MockJdbcDriver(mockDriver)
+    DriverManager.registerDriver(namedDriver)
+  }
+
+  override def afterAll(): Unit = {
+    DriverManager.deregisterDriver(namedDriver)
+    super.afterAll()
+  }
+
+  val valueSchema = SchemaBuilder.struct()
+    .name("schema for single table")
+    .field("id", Schema.INT32_SCHEMA)
+  val value = new Struct(valueSchema).put("id", 23)
+
+  val keySchema = SchemaBuilder.struct()
+    .name("schema for single table")
+    .field("id", Schema.INT32_SCHEMA)
+  val key = new Struct(keySchema).put("id", 23)
+
+  test("sink create and insert") {
+    verifySinkTask(null, null, valueSchema, value)
+  }
+
+  test("sink create and insert with key-schema") {
+    verifySinkTask(keySchema, key, valueSchema, value)
+  }
+
+  def verifySinkTask(keySchema: Schema, key: Any, valueSchema: Schema, value: Any): Unit = {
+    mockTaskContext = mock(classOf[SinkTaskContext])
+    mockConnection = mock(classOf[Connection])
+    mockStatement = mock(classOf[Statement])
+    mockPreparedStatement = mock(classOf[PreparedStatement])
+    val mockDatabaseMetaData = mock(classOf[DatabaseMetaData])
+    val mockResultSetTableExists = mock(classOf[ResultSet])
+    val mockResultSetSelectMetaData = mock(classOf[ResultSet])
+    val mockResultSetMetaData = mock(classOf[ResultSetMetaData])
+
+    when(mockDriver.connect(ArgumentMatchers.anyString, ArgumentMatchers.any(classOf[java.util.Properties]))).thenReturn(mockConnection)
+    when(mockConnection.getMetaData).thenReturn(mockDatabaseMetaData)
+    when(mockDatabaseMetaData.getTables(null, "TEST", "EMPLOYEES_SINK", null)).thenReturn(mockResultSetTableExists)
+    when(mockConnection.createStatement).thenReturn(mockStatement)
+
+    when(mockStatement.execute(ArgumentMatchers.anyString)).thenReturn(true)
+    when(mockStatement.executeQuery(ArgumentMatchers.anyString)).thenReturn(mockResultSetSelectMetaData)
+    when(mockResultSetSelectMetaData.getMetaData).thenReturn(mockResultSetMetaData)
+    when(mockResultSetMetaData.getColumnCount).thenReturn(1)
+    when(mockResultSetMetaData.getColumnName(1)).thenReturn("id")
+    when(mockResultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER)
+    when(mockResultSetMetaData.isNullable(1)).thenReturn(ResultSetMetaData.columnNullable)
+    when(mockConnection.prepareStatement(ArgumentMatchers.anyString)).thenReturn(mockPreparedStatement)
+
+    val task: HANASinkTask = new HANASinkTask()
+    task.initialize(mockTaskContext)
+
+    task.start(singleTableConfig())
+
+    task.put(Collections.singleton(new SinkRecord(TOPIC, 1, keySchema, key, valueSchema, value, 0)))
+
+    verify(mockStatement).execute("CREATE COLUMN TABLE \"TEST\".\"EMPLOYEES_SINK\" (\"id\" INTEGER NOT NULL)")
+    verify(mockConnection).prepareStatement("INSERT INTO \"TEST\".\"EMPLOYEES_SINK\" (\"id\") VALUES (?)")
+    verify(mockPreparedStatement).setInt(1, 23)
+    verify(mockPreparedStatement).addBatch()
+    verify(mockPreparedStatement).executeBatch
+    verify(mockPreparedStatement).clearParameters()
+    verify(mockPreparedStatement).close()
+  }
+
+
+  protected def singleTableConfig(): java.util.Map[String, String] = {
+    val props = new util.HashMap[String, String]()
+
+    props.put("connection.url", TEST_CONNECTION_URL)
+    props.put("connection.user", "sa")
+    props.put("connection.password", "sa")
+    props.put("auto.create", "true")
+    props.put("topics", TOPIC)
+    props.put(s"$TOPIC.table.name", SINGLE_TABLE_NAME_FOR_INSERT)
+    props
+  }
+}


### PR DESCRIPTION
- The (N)VARCHAR size limit is raised to 5000 to be aligned with HANA's behavior.
- The presence of keySchema caused a table creation error and this is fixed.
- Mockito based DB tests are added for SinkTask.