### PR TITLE
Add Upsert, Delete support to Sink; add an example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,4 +10,5 @@
 * [persons4ds](persons4ds/README.md) : distributed version of persons4 using Docker with Strimzi Kafka image
 * [persons1ks](persons1ks/README.md) : distributed version of persons1 in Kubernetes with Strimzi Kafka image
 * [persons4ks](persons4ks/README.md) : distributed version of persons4 in Kubernetes with Strimzi Kafka image
+* [inventory7db](inventory7db/README.md) : Debezium MySQL and HANA connectors to copy tables from MySQL to HANA using Debezium's table change events
 

--- a/examples/inventory7db/README.md
+++ b/examples/inventory7db/README.md
@@ -1,0 +1,350 @@
+### Example inventory7db: kafka-hana-connect using debezium record state extraction to HANA
+
+This example uses Debezium MySQL connector and HANA connector to copy tables from MySQL to HANA using table change events or CDC events. Concretely, the table change events are extracted from MySQL database by MySQL connector. There change event records are sent to HANA connector, where each record is transformed into a series of normal records by Debezium's [Event Flattening transformation](https://debezium.io/docs/configuration/event-flattening/) and subsequently the corresponding record is inserted, updated, or deleted in the corresponding HANA table.
+
+For further information on Debezium and its MySQL connector, refer to [Debezium documentation](https://debezium.io/documentation/reference/index.html).
+
+#### Prerequisites
+
+- This project is built (or its jar file is available)
+- Access to HANA
+- Docker
+
+#### Running
+
+This description assumes Docker and Docker-Compose are available on local machine. 
+
+##### Step 1: Build Docker image for kafka-connector-hana
+
+Use the instruction for `examples/persons1db` to build the Docker image.
+
+
+##### Step 2: Starting Zookeeper, Kafka, Kafka-Connect, MySQL Database and Command Line Client
+
+The docker-compose.yaml file defines zookeeper, kafka, mysql, and connect services. It is noted that Kafka broker uses its advertised host set to `host.docker.internal:9092` assuming this host name is resolvable from the containers and at the host. This allows Kafka broker to be accessed from the container of Kafka-Connect and from the host for inspection.
+
+Run `docker-compose up` to start the containers.
+
+```
+$ docker-compose up
+Creating network "inventory7db_default" with the default driver
+Creating inventory7db_zookeeper_1 ... done
+Creating inventory7db_mysql_1     ... done
+Creating inventory7db_kafka_1     ... done
+Creating inventory7db_connect_1   ... done
+Attaching to inventory7db_mysql_1, inventory7db_zookeeper_1, inventory7db_kafka_1, inventory7db_connect_1
+...
+```
+
+After starting the Docker containers using docker-compose, we can verify whether Kafka-Connect is running using curl.
+
+```
+$ curl -i http://localhost:8083/
+HTTP/1.1 200 OK
+Date: Wed, 09 Sep 2020 22:44:49 GMT
+Content-Type: application/json
+Content-Length: 91
+Server: Jetty(9.4.24.v20191120)
+
+{"version":"2.5.0","commit":"66563e712b0b9f84","kafka_cluster_id":"1NEvm9a4TW2t-f5Jkk4peg"}
+$
+$ curl -i http://localhost:8083/connectors
+HTTP/1.1 200 OK
+Date: Wed, 09 Sep 2020 22:45:35 GMT
+Content-Type: application/json
+Content-Length: 2
+Server: Jetty(9.4.24.v20191120)
+
+[]
+$
+```
+
+The above result shows that Kafka Connect using Kafka 2.5.0 is running and there is no connector deployed.
+
+To start MySQL Command Line client, run the following Docker command.
+
+```
+docker run -it --rm --name mysqlterm --rm mysql:5.7 sh -c 'exec mysql -h"host.docker.internal" -P"3306" -u"root" -p"debezium"'
+
+```
+
+This will start the command line client.
+
+```
+docker run -it --rm --name mysqlterm --rm mysql:5.7 sh -c 'exec mysql -h"host.docker.internal" -P"3306" -u"root" -p"debezium"'
+mysql: [Warning] Using a password on the command line interface can be insecure.
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 2
+Server version: 5.7.31-log MySQL Community Server (GPL)
+
+Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```
+
+This Debezium MySQL Database contains several tables. We will use user `mysqluser` and table `inventory.customers` in this scenario.
+To run this scenario, the user needs certain authorization grants. Run the following commands to add the required grants to user `mysqluser`. Subsequently inspect the content of the tables.
+
+```
+mysql> show grants for 'mysqluser';
++----------------------------------------------------------+
+| Grants for mysqluser@%                                   |
++----------------------------------------------------------+
+| GRANT USAGE ON *.* TO 'mysqluser'@'%'                    |
+| GRANT ALL PRIVILEGES ON `inventory`.* TO 'mysqluser'@'%' |
++----------------------------------------------------------+
+2 rows in set (0.00 sec)
+
+mysql> GRANT RELOAD, SUPER, REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'mysqluser';
+Query OK, 0 rows affected (0.01 sec)
+
+mysql> show grants for 'mysqluser';
++--------------------------------------------------------------------------------------+
+| Grants for mysqluser@%                                                               |
++--------------------------------------------------------------------------------------+
+| GRANT RELOAD, SUPER, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'mysqluser'@'%' |
+| GRANT ALL PRIVILEGES ON `inventory`.* TO 'mysqluser'@'%'                             |
++--------------------------------------------------------------------------------------+
+2 rows in set (0.00 sec)
+
+mysql> use inventory
+Reading table information for completion of table and column names
+You can turn off this feature to get a quicker startup with -A
+
+Database changed
+mysql> show tables
+    -> ;
++---------------------+
+| Tables_in_inventory |
++---------------------+
+| addresses           |
+| customers           |
+| geom                |
+| orders              |
+| products            |
+| products_on_hand    |
++---------------------+
+6 rows in set (0.00 sec)
+
+mysql> SELECT * FROM customers;
++------+------------+-----------+-----------------------+
+| id   | first_name | last_name | email                 |
++------+------------+-----------+-----------------------+
+| 1001 | Sally      | Thomas    | sally.thomas@acme.com |
+| 1002 | George     | Bailey    | gbailey@foobar.com    |
+| 1003 | Edward     | Walker    | ed@walker.com         |
+| 1004 | Anne       | Kretchmar | annek@noanswer.org    |
++------+------------+-----------+-----------------------+
+4 rows in set (0.00 sec)
+```
+
+
+##### Step 3: Installing MySQL and HANA connectors
+
+We prepare for the connector json files using the json files `connect-mysql-source-7.json` and `connect-hana-sink-7.json`. Adjust the connection properties of  `connect-hana-sink-7.json`.
+
+```
+{
+    "name": "inventory-hana-sink",
+    "config": {
+        "connector.class": "com.sap.kafka.connect.source.hana.HANASourceConnector",
+        "tasks.max": "1",
+        "topics": "dbserver1.inventory.customers",
+        "connection.url": "jdbc:sap://<host>/",
+        "connection.user": "${file:/kafka/custom-config/secrets.properties:connection1-user}",
+        "connection.password": "${file:/kafka/custom-config/secrets.properties:connection1-password}",
+        "transforms": "unwrap",
+        "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+        "transforms.unwrap.drop.tombstones": "false",
+        "transforms.unwrap.delete.handling.mode": "rewrite",
+        "auto.create": "true",
+        "dbserver1.inventory.customers.insert.mode": "upsert",
+        "dbserver1.inventory.customers.delete.enabled": "false",
+        "dbserver1.inventory.customers.pk.fields": "id",
+        "dbserver1.inventory.customers.pk.mode": "record_key",
+        "dbserver1.inventory.customers.table.name": "\"<schemaname>\".\"INVENTORY_CUSTOMERS\""
+    }
+}
+```
+
+The above configuration uses Debezium's Event Flattening SMT https://debezium.io/docs/configuration/event-flattening/ to convert the event records to the annotated records that can interpreted by HANA connector. The insert mode `insert.mode` must be set to `upsert` and the primary keys must be specified in `pk.fields` using `pk.mode`. When `delete.enabled` is set to false, the deletion of a record will only mark the record as deleted. When `delete.enabled` is set to true, the deletion of a record will delete the record.
+
+We deploy the connectors by posting the connector configuration json files to the Kafka Connect's API.
+
+```
+$ curl -i -X POST -H "Content-Type:application/json" -d @connect-mysql-source-7.json http://localhost:8083/connectors/
+HTTP/1.1 201 Created
+Date: Tue, 12 Jan 2021 22:29:00 GMT
+Location: http://localhost:8083/connectors/inventory-mysql-source
+Content-Type: application/json
+Content-Length: 630
+Server: Jetty(9.4.24.v20191120)
+
+{"name":"inventory-mysql-source","config":{"connector.class":"io.debezium.connector.mysql.MySqlConnector","tasks.max":"1","database.hostname":"mysql","database.port":"3306","database.user":"${file:/kafka/custom-config/tmp-secrets.properties:connection2-user}","database.password":"${file:/kafka/custom-config/tmp-secrets.properties:connection2-password}","database.server.id":"184054","d
+...
+$
+$ curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" -d @tmp-connect-hana-sink-7.json http://localhost:8083/connectors/
+HTTP/1.1 201 Created
+Date: Tue, 12 Jan 2021 22:30:10 GMT
+Location: http://localhost:8083/connectors/inventory-hana-sink
+Content-Type: application/json
+Content-Length: 764
+Server: Jetty(9.4.24.v20191120)
+
+{"name":"inventory-hana-sink","config":{"connector.class":"com.sap.kafka.connect.sink.hana.HANASinkConnector","tasks.max":"1","topics":"dbserver1.inventory.customers","connection.url":"jdbc:sap://...
+$
+$ curl http://localhost:8083/connectors/
+["inventory-mysql-source","inventory-hana-sink"]
+$
+```
+
+The above result shows that the connectors are deployed.
+
+##### Step 5: Interactively update the MySQL Table and verify the result in HANA Table
+
+After starting the connectors, you will find table `inventory_customers` in HANA. The replicated HANA table has the additional column `__deleted`. When the connector is configured with `delete.enabled=false`, the deleted record will be kept but the value of this column will be set to true. In contrast, when the connector is configured with `delete.enabled=true`, the deleted record will be deleted.
+
+```
+select * from inventory_customers;
+  id  first_name  last_name  email                  __deleted
+----  ----------  ---------  ---------------------  ---------
+1001  Sally       Thomas     sally.thomas@acme.com  false    
+1002  George      Bailey     gbailey@foobar.com     false    
+1003  Edward      Walker     ed@walker.com          false    
+1004  Anne        Kretchmar  annek@noanswer.org     false    
+```
+
+At MySQL Command Line Client,  run the following SQL to insert a new record.
+```
+mysql> INSERT INTO customers VALUES (default, "Sarah", "Thompson", "kitt@acme.com");
+Query OK, 1 row affected (0.00 sec)
+
+mysql> select * from customers;
++------+------------+-----------+-----------------------+
+| id   | first_name | last_name | email                 |
++------+------------+-----------+-----------------------+
+| 1001 | Sally      | Thomas    | sally.thomas@acme.com |
+| 1002 | George     | Bailey    | gbailey@foobar.com    |
+| 1003 | Edward     | Walker    | ed@walker.com         |
+| 1004 | Anne       | Kretchmar | annek@noanswer.org    |
+| 1005 | Sarah      | Thompson  | kitt@acme.com         |
++------+------------+-----------+-----------------------+
+5 rows in set (0.00 sec)
+
+mysql> 
+```
+
+At HANA, verify the table to have this record added.
+```
+select * from inventory_customers;
+  id  first_name  last_name  email                  __deleted
+----  ----------  ---------  ---------------------  ---------
+1001  Sally       Thomas     sally.thomas@acme.com  false    
+1002  George      Bailey     gbailey@foobar.com     false    
+1003  Edward      Walker     ed@walker.com          false    
+1004  Anne        Kretchmar  annek@noanswer.org     false    
+1005  Sarah       Thompson   kitt@acme.com          false    
+```
+
+At MySQL Command Line Client,  run the following SQL to update one record.
+
+```
+mysql> UPDATE customers SET first_name='Anne Marie' WHERE id=1004;
+Query OK, 1 row affected (0.02 sec)
+Rows matched: 1  Changed: 1  Warnings: 0
+
+mysql> select * from customers;
++------+------------+-----------+-----------------------+
+| id   | first_name | last_name | email                 |
++------+------------+-----------+-----------------------+
+| 1001 | Sally      | Thomas    | sally.thomas@acme.com |
+| 1002 | George     | Bailey    | gbailey@foobar.com    |
+| 1003 | Edward     | Walker    | ed@walker.com         |
+| 1004 | Anne Marie | Kretchmar | annek@noanswer.org    |
+| 1005 | Sarah      | Thompson  | kitt@acme.com         |
++------+------------+-----------+-----------------------+
+5 rows in set (0.00 sec)
+
+mysql> 
+```
+
+At HANA, verify the updated table.
+```
+select * from inventory_customers;
+  id  first_name  last_name  email                  __deleted
+----  ----------  ---------  ---------------------  ---------
+1001  Sally       Thomas     sally.thomas@acme.com  false    
+1002  George      Bailey     gbailey@foobar.com     false    
+1003  Edward      Walker     ed@walker.com          false    
+1005  Sarah       Thompson   kitt@acme.com          false    
+1004  Anne Marie  Kretchmar  annek@noanswer.org     false
+```
+
+At MySQL Command Line Client,  run the following SQL to delete one record.
+
+```
+mysql> DELETE FROM customers WHERE id=1005;
+Query OK, 1 row affected (0.01 sec)
+
+mysql> select * from customers;
++------+------------+-----------+-----------------------+
+| id   | first_name | last_name | email                 |
++------+------------+-----------+-----------------------+
+| 1001 | Sally      | Thomas    | sally.thomas@acme.com |
+| 1002 | George     | Bailey    | gbailey@foobar.com    |
+| 1003 | Edward     | Walker    | ed@walker.com         |
+| 1004 | Anne Marie | Kretchmar | annek@noanswer.org    |
++------+------------+-----------+-----------------------+
+4 rows in set (0.00 sec)
+
+mysql> 
+```
+
+At HANA, verify the updated table. Depending on the connector's `delete.enabled` value, the deleted record will be only marked as deleted or deleted, as shown below.
+
+When `deleted.enabled` is set to false
+```
+select * from inventory_customers;
+  id  first_name  last_name  email                  __deleted
+----  ----------  ---------  ---------------------  ---------
+1001  Sally       Thomas     sally.thomas@acme.com  false    
+1002  George      Bailey     gbailey@foobar.com     false    
+1003  Edward      Walker     ed@walker.com          false    
+1004  Anne Marie  Kretchmar  annek@noanswer.org     false    
+1005  Sarah       Thompson   kitt@acme.com          true
+```
+
+When `deleted.enabled` is set to true
+```
+select * from inventory_customers;
+  id  first_name  last_name  email                  __deleted
+----  ----------  ---------  ---------------------  ---------
+1001  Sally       Thomas     sally.thomas@acme.com  false    
+1002  George      Bailey     gbailey@foobar.com     false    
+1003  Edward      Walker     ed@walker.com          false    
+1004  Anne Marie  Kretchmar  annek@noanswer.org     false
+```
+
+##### Step 6: Shut down
+
+Use `docker-compose down` to shutdown the containers.
+
+```
+$ docker-compose down
+Stopping inventory7db_connect_1   ... done
+Stopping inventory7db_kafka_1     ... done
+Stopping inventory7db_zookeeper_1 ... done
+Stopping inventory7db_mysql_1     ... done
+Removing inventory7db_connect_1   ... done
+Removing inventory7db_kafka_1     ... done
+Removing inventory7db_zookeeper_1 ... done
+Removing inventory7db_mysql_1     ... done
+Removing network inventory7db_default
+$ 
+```

--- a/examples/inventory7db/connect-hana-sink-7.json
+++ b/examples/inventory7db/connect-hana-sink-7.json
@@ -1,0 +1,22 @@
+{
+    "name": "inventory-hana-sink",
+    "config": {
+        "connector.class": "com.sap.kafka.connect.source.hana.HANASourceConnector",
+        "tasks.max": "1",
+        "topics": "dbserver1.inventory.customers",
+        "connection.url": "jdbc:sap://<host>/",
+        "connection.user": "${file:/kafka/custom-config/secrets.properties:connection1-user}",
+        "connection.password": "${file:/kafka/custom-config/secrets.properties:connection1-password}",
+        "transforms": "unwrap",
+        "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+        "transforms.unwrap.drop.tombstones": "false",
+        "transforms.unwrap.delete.handling.mode": "rewrite",
+        "auto.create": "true",
+        "dbserver1.inventory.customers.insert.mode": "upsert",
+        "dbserver1.inventory.customers.delete.enabled": "false",
+        "dbserver1.inventory.customers.pk.fields": "id",
+        "dbserver1.inventory.customers.pk.mode": "record_key",
+        "dbserver1.inventory.customers.table.name": "\"<schemaname>\".\"INVENTORY_CUSTOMERS\""
+    }
+}
+

--- a/examples/inventory7db/connect-mysql-source-7.json
+++ b/examples/inventory7db/connect-mysql-source-7.json
@@ -1,0 +1,16 @@
+{
+  "name": "inventory-mysql-source",  
+  "config": {  
+    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+    "tasks.max": "1",  
+    "database.hostname": "mysql",  
+    "database.port": "3306",
+    "database.user": "${file:/kafka/custom-config/secrets.properties:connection2-user}",
+    "database.password": "${file:/kafka/custom-config/secrets.properties:connection2-password}",
+    "database.server.id": "184054",  
+    "database.server.name": "dbserver1",  
+    "database.include.list": "inventory",  
+    "database.history.kafka.bootstrap.servers": "kafka:9092",  
+    "database.history.kafka.topic": "schema-changes.inventory"  
+  }
+}

--- a/examples/inventory7db/custom-config/secrets.properties
+++ b/examples/inventory7db/custom-config/secrets.properties
@@ -1,0 +1,4 @@
+connection1-user=<username>
+connection1-password=<password>
+connection2-user=mysqluser
+connection2-password=mysqlpw

--- a/examples/inventory7db/docker-compose.yaml
+++ b/examples/inventory7db/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '2'
+
+services:
+
+  zookeeper:
+    image: debezium/zookeeper:1.2
+    ports:
+    - 2181:2181
+
+  kafka:
+    image: debezium/kafka:1.2
+    depends_on:
+    - zookeeper
+    ports:
+    - 9092:9092
+    environment:
+      ADVERTISED_LISTENERS: PLAINTEXT://host.docker.internal:9092
+      LISTENERS: PLAINTEXT://0.0.0.0:9092
+      ZOOKEEPER_CONNECT: zookeeper:2181
+
+  mysql:
+    image: debezium/example-mysql:1.2
+    ports:
+    - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: debezium
+      MYSQL_USER: mysqluser
+      MYSQL_PASSWORD: mysqlpw 
+    
+  connect:
+    image: debezium-connector-hana-min:latest
+    volumes:
+    - ./custom-config:/kafka/custom-config
+    depends_on:
+    - kafka
+    ports:
+    - 8083:8083
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      CONNECT_CONFIG_PROVIDERS: file
+      CONNECT_CONFIG_PROVIDERS_FILE_CLASS: org.apache.kafka.common.config.provider.FileConfigProvider
+      GROUP_ID: 1
+      CONFIG_STORAGE_TOPIC: my_connect_configs
+      OFFSET_STORAGE_TOPIC: my_connect_offsets
+      STATUS_STORAGE_TOPIC: my_connect_statuses
+
+volumes:
+  custom-config:

--- a/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
@@ -355,15 +355,16 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
    * @param batchSize The batch size parameter
    */
    def loadData(namespace: Option[String],
-                             tableName: String,
-                            connection: Connection,
-                             schema: MetaSchema,
-                             records: Seq[SinkRecord],
-                             batchSize: Int): Unit = {
+                tableName: String,
+                connection: Connection,
+                schema: MetaSchema,
+                records: Seq[SinkRecord],
+                insertMode: String,
+                batchSize: Int): Unit = {
      ExecuteWithExceptions[Unit, Exception, HANAJdbcException] (
       new HANAJdbcException(s"loading data into $tableName is not successful")) { () =>
        val fullTableName = tableWithNamespace(namespace, tableName)
-       HANAPartitionLoader.loadPartition(connection, fullTableName, records.iterator, schema, batchSize)
+       HANAPartitionLoader.loadPartition(connection, fullTableName, records.iterator, schema, insertMode, batchSize)
      }
   }
 
@@ -371,10 +372,11 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
                connection: Connection,
                schema: MetaSchema,
                records: Seq[SinkRecord],
+               insertMode: String,
                batchSize: Int): Unit = {
     ExecuteWithExceptions[Unit, Exception, HANAJdbcException] (
       new HANAJdbcException(s"loading data into $collectionName is not successful")) { () =>
-      HANAPartitionLoader.loadPartitionForJsonStore(connection, collectionName, records.iterator, schema, batchSize)
+      HANAPartitionLoader.loadPartitionForJsonStore(connection, collectionName, records.iterator, schema, insertMode, batchSize)
     }
   }
 

--- a/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
+++ b/src/main/scala/com/sap/kafka/client/hana/HANAJdbcClient.scala
@@ -360,11 +360,12 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
                 schema: MetaSchema,
                 records: Seq[SinkRecord],
                 insertMode: String,
+                deleteEnabled: Boolean,
                 batchSize: Int): Unit = {
      ExecuteWithExceptions[Unit, Exception, HANAJdbcException] (
       new HANAJdbcException(s"loading data into $tableName is not successful")) { () =>
        val fullTableName = tableWithNamespace(namespace, tableName)
-       HANAPartitionLoader.loadPartition(connection, fullTableName, records.iterator, schema, insertMode, batchSize)
+       HANAPartitionLoader.loadPartition(connection, fullTableName, records.iterator, schema, insertMode, deleteEnabled, batchSize)
      }
   }
 
@@ -373,10 +374,11 @@ case class HANAJdbcClient(hanaConfiguration: HANAConfig)  {
                schema: MetaSchema,
                records: Seq[SinkRecord],
                insertMode: String,
+               deleteEnabled: Boolean,
                batchSize: Int): Unit = {
     ExecuteWithExceptions[Unit, Exception, HANAJdbcException] (
       new HANAJdbcException(s"loading data into $collectionName is not successful")) { () =>
-      HANAPartitionLoader.loadPartitionForJsonStore(connection, collectionName, records.iterator, schema, insertMode, batchSize)
+      HANAPartitionLoader.loadPartitionForJsonStore(connection, collectionName, records.iterator, schema, insertMode, deleteEnabled, batchSize)
     }
   }
 

--- a/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
@@ -1,8 +1,10 @@
 package com.sap.kafka.connect.config
 
+import org.slf4j.{Logger, LoggerFactory}
+
 
 abstract class BaseConfig(props: Map[String, String]) {
-
+  private val log: Logger = LoggerFactory.getLogger(classOf[BaseConfig])
 
   /**
     * DB Jdbc user for source & sink
@@ -121,10 +123,11 @@ abstract class BaseConfig(props: Map[String, String]) {
         * Default value is none.
         */
       if (key == s"$topic.table.partition.mode") {
-        if (value == BaseConfigConstants.ROUND_ROBIN_PARTITION)
-          topicPropMap.put("table.partition.mode", value)
-        else if (value == BaseConfigConstants.HASH_PARTITION)
-          topicPropMap.put("table.partition.mode", value)
+        value match {
+          case BaseConfigConstants.ROUND_ROBIN_PARTITION | BaseConfigConstants.HASH_PARTITION =>
+            topicPropMap.put("table.partition.mode", value)
+          case _ => log.warn(s"Ignoring invalid table.partition.mode $value")
+        }
       }
 
       /**
@@ -133,6 +136,18 @@ abstract class BaseConfig(props: Map[String, String]) {
         */
       if (key == s"$topic.table.partition.count") {
         topicPropMap.put("table.partition.count", value)
+      }
+
+      /**
+        * insert mode to be used by sink.
+        * Default is insert.
+        */
+      if (key == s"$topic.insert.mode") {
+        value match {
+          case BaseConfigConstants.INSERT_MODE_INSERT | BaseConfigConstants.INSERT_MODE_UPSERT =>
+            topicPropMap.put("insert.mode", value)
+          case _ => log.warn(s"Ignoring invalid insert.mode $value")
+        }
       }
     }
 

--- a/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
@@ -149,6 +149,16 @@ abstract class BaseConfig(props: Map[String, String]) {
           case _ => log.warn(s"Ignoring invalid insert.mode $value")
         }
       }
+
+      if (key == s"$topic.delete.enabled") {
+        value match {
+          case "true" | "false" =>
+            topicPropMap.put("delete.enabled", value)
+          case _ =>
+            log.warn(s"Ignoring invalid delete.enabled $value")
+        }
+      }
+
     }
 
     if (topicPropMap.get("pk.mode").isEmpty) {

--- a/src/main/scala/com/sap/kafka/connect/config/BaseParameters.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/BaseParameters.scala
@@ -12,6 +12,9 @@ object BaseConfigConstants {
   val QUERY_MODE_TABLE = "table"
   val QUERY_MODE_SQL = "query"
 
+  val INSERT_MODE_INSERT = "insert"
+  val INSERT_MODE_UPSERT = "upsert"
+
   val MODE_BULK = "bulk"
   val MODE_INCREMENTING = "incrementing"
 

--- a/src/main/scala/com/sap/kafka/connect/config/hana/HANAConfig.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/hana/HANAConfig.scala
@@ -55,6 +55,10 @@ case class HANAConfig(props: Map[String, String]) extends BaseConfig(props: Map[
     if (topicPropMap.get("insert.mode").isEmpty) {
       topicPropMap.put("insert.mode", BaseConfigConstants.INSERT_MODE_INSERT)
     }
+
+    if (topicPropMap.get("delete.enabled").isEmpty) {
+      topicPropMap.put("delete.enabled", "false")
+    }
     topicPropMap.toMap
   }
 }

--- a/src/main/scala/com/sap/kafka/connect/config/hana/HANAConfig.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/hana/HANAConfig.scala
@@ -52,6 +52,9 @@ case class HANAConfig(props: Map[String, String]) extends BaseConfig(props: Map[
         s" an incrementing column must be specified")
     }
 
+    if (topicPropMap.get("insert.mode").isEmpty) {
+      topicPropMap.put("insert.mode", BaseConfigConstants.INSERT_MODE_INSERT)
+    }
     topicPropMap.toMap
   }
 }

--- a/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkRecordsCollector.scala
+++ b/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkRecordsCollector.scala
@@ -155,10 +155,11 @@ class HANASinkRecordsCollector(var tableName: String, client: HANAJdbcClient,
   }
 
   private[sink] def flush(): Seq[SinkRecord] = {
+    val insertMode = config.topicProperties(records.head.topic())("insert.mode")
     if (config.topicProperties(records.head.topic())("table.type") == BaseConfigConstants.COLLECTION_TABLE_TYPE) {
-      client.loadData(getTableName._2, connection, metaSchema, records, config.batchSize)
+      client.loadData(getTableName._2, connection, metaSchema, records, insertMode, config.batchSize)
     } else {
-      client.loadData(getTableName._1, getTableName._2, connection, metaSchema, records, config.batchSize)
+      client.loadData(getTableName._1, getTableName._2, connection, metaSchema, records, insertMode, config.batchSize)
     }
     val flushedRecords = records
     records = Seq.empty[SinkRecord]

--- a/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkRecordsCollector.scala
+++ b/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkRecordsCollector.scala
@@ -48,6 +48,10 @@ class HANASinkRecordsCollector(var tableName: String, client: HANAJdbcClient,
     val recordHead = records.head
     val recordSchema = KeyValueSchema(recordHead.keySchema(), recordHead.valueSchema())
 
+    if (recordHead.valueSchema == null && recordHead.value == null) {
+      // skip the delete marker
+      return
+    }
     initTableConfig(getTableName._1,getTableName._2, recordHead.topic()) match
     {
       case true =>
@@ -155,14 +159,17 @@ class HANASinkRecordsCollector(var tableName: String, client: HANAJdbcClient,
   }
 
   private[sink] def flush(): Seq[SinkRecord] = {
-    val insertMode = config.topicProperties(records.head.topic())("insert.mode")
-    if (config.topicProperties(records.head.topic())("table.type") == BaseConfigConstants.COLLECTION_TABLE_TYPE) {
-      client.loadData(getTableName._2, connection, metaSchema, records, insertMode, config.batchSize)
-    } else {
-      client.loadData(getTableName._1, getTableName._2, connection, metaSchema, records, insertMode, config.batchSize)
-    }
     val flushedRecords = records
-    records = Seq.empty[SinkRecord]
+    if (!records.isEmpty) {
+      val insertMode = config.topicProperties(records.head.topic())("insert.mode")
+      val deleteEnabled = config.topicProperties(records.head.topic())("delete.enabled").toBoolean
+      if (config.topicProperties(records.head.topic())("table.type") == BaseConfigConstants.COLLECTION_TABLE_TYPE) {
+        client.loadData(getTableName._2, connection, metaSchema, records, insertMode, deleteEnabled, config.batchSize)
+      } else {
+        client.loadData(getTableName._1, getTableName._2, connection, metaSchema, records, insertMode, deleteEnabled, config.batchSize)
+      }
+      records = Seq.empty[SinkRecord]
+    }
     flushedRecords
   }
 

--- a/src/main/scala/com/sap/kafka/connect/sink/hana/HANAWriter.scala
+++ b/src/main/scala/com/sap/kafka/connect/sink/hana/HANAWriter.scala
@@ -61,8 +61,10 @@ class HANAWriter(config: HANAConfig, hanaClient: HANAJdbcClient,
           tableRecordsCollector.add(collectionAsScalaIterableConverter(recordsPerTopic).asScala.toSeq)
       }
     }
-    flush(tableCache.toMap)
-    log.info("flushing records to HANA successful")
+    if (!tableCache.isEmpty) {
+      flush(tableCache.toMap)
+      log.info("flushing records to HANA successful")
+    }
   }
 
   private def flush(tableCache: Map[String, HANASinkRecordsCollector]): Unit = {

--- a/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
@@ -2,7 +2,7 @@ package com.sap.kafka.connect.sink
 
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
-import java.{sql, util}
+import java.util
 import java.util.TimeZone
 
 import com.sap.kafka.connect.MockJdbcClient


### PR DESCRIPTION
* Upsert is configured by setting `{topic}.table.type` to `upsert`. The default is `insert`. The upsert mode requires the primary key to be set.
* Delete is triggered when a tombstone record is received (i.e., an empty record with only the key being set).
* examples/inventory7db is a Debezium MySQL to HANA scenario where the above feature is used.
