### PR TITLE
fix null version shown in the log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkTask.scala
+++ b/src/main/scala/com/sap/kafka/connect/sink/hana/HANASinkTask.scala
@@ -15,6 +15,8 @@ class HANASinkTask extends GenericSinkTask {
   private val tableCache = scala.collection.mutable.Map[String, HANASinkRecordsCollector]()
   var hanaClient: HANAJdbcClient = _
 
+  override def version(): String = getClass.getPackage.getImplementationVersion
+
   override def start(props: util.Map[String, String]): Unit = {
     log.info("Starting Kafka-Connect task")
     config = HANAParameters.getConfig(props)

--- a/src/main/scala/com/sap/kafka/connect/source/hana/HANASourceTask.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/hana/HANASourceTask.scala
@@ -14,9 +14,8 @@ class HANASourceTask extends GenericSourceTask {
     this.jdbcClient = jdbcClient
   }
 
-  override def version(): String = {
-    getClass.getPackage.getImplementationVersion
-  }
+  override def version(): String = getClass.getPackage.getImplementationVersion
+
 
   override def createJdbcClient(): HANAJdbcClient = {
     config match {


### PR DESCRIPTION
The default scala jar plugin doesn't generate the version entries in MANIFEST. This results in no version info shown in the log.
```
connect_1    | 2021-01-24 21:48:54,527 INFO   ||  Instantiated connector test-topic-source with version null of type class com.sap.kafka.connect.source.hana.HANASourceConnector   [org.apache.kafka.connect.runtime.Worker]
```
This patch adds the correct MANIFEST entries and the version will be shown in the log.
```
connect_1    | 2021-01-24 21:57:44,752 INFO   ||  Instantiated connector test-topic-source with version 0.9.1-SNAPSHOT of type class com.sap.kafka.connect.source.hana.HANASourceConnector   [org.apache.kafka.connect.runtime.Worker]
...
connect_1    | 2021-01-24 21:57:45,321 INFO   ||  Instantiated task test-topic-source-0 with version 0.9.1-SNAPSHOT of type com.sap.kafka.connect.source.hana.HANASourceTask   [org.apache.kafka.connect.runtime.Worker]
...
connect_1    | 2021-01-24 21:57:55,629 INFO   ||  Instantiated connector test-topic-sink with version 0.9.1-SNAPSHOT of type class com.sap.kafka.connect.sink.hana.HANASinkConnector   [org.apache.kafka.connect.runtime.Worker]
...
connect_1    | 2021-01-24 21:57:56,671 INFO   ||  Instantiated task test-topic-sink-0 with version 0.9.1-SNAPSHOT of type com.sap.kafka.connect.sink.hana.HANASinkTask   [org.apache.kafka.connect.runtime.Worker]
```