### PR TITLE
Log the error cause when getting a connection error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
     </modules>
     <profiles>
         <profile>
+            <id>fastinstall</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/src/main/scala/com/sap/kafka/utils/ExecuteWithExceptions.scala
+++ b/src/main/scala/com/sap/kafka/utils/ExecuteWithExceptions.scala
@@ -21,7 +21,7 @@ object ExecuteWithExceptions {
     */
   def defaultThrowException[TE <: Exception, BE <: ConnectorException](exception: TE,
                                                                        connectorException: BE): BE = {
-    log.error(connectorException.getMessage)
+    log.error(exception.getMessage)
     connectorException.initCause(exception)
     connectorException
   }


### PR DESCRIPTION
This change should log the error cause when there is some error at connecting to HANA.
Previously, the error was logged as

```
connect_1    | [2021-04-23 14:08:17,450] INFO Read records from HANA (com.sap.kafka.connect.source.hana.HANASourceTask:31)
connect_1    | [2021-04-23 14:08:17,937] ERROR Cannot acquire a connection (com.sap.kafka.utils.ExecuteWithExceptions$:24)
```

With this change, the error will be logged as

```
connect_1    | [2021-04-23 15:22:54,530] INFO Read records from HANA (com.sap.kafka.connect.source.hana.HANASourceTask:31)
connect_1    | [2021-04-23 15:22:55,062] ERROR Opening a connection failed: [10]: authentication failed (com.sap.kafka.utils.ExecuteWithExceptions$:24)
...

connect_1    | [2021-04-23 15:27:25,532] INFO WorkerSourceTask{id=test-topic-1-source-0} flushing 0 outstanding messages for offset commit (org.apache.kafka.connect.runtime.WorkerSourceTask:495)
connect_1    | [2021-04-23 15:27:25,755] ERROR Opening a connection failed: SAP DBTech JDBC: Cannot connect to jdbc:sap://...
```

In addition, some unnecessary code has been removed (e.g. isFailedToOpenConnectionException).

Signed-off-by: Aki Yoshida <elakito@gmail.com>