### PR TITLE
Support alter-table at sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ The full list of configuration options for `kafka connector for SAP Systems` is 
 
   * `topics` - This setting can be used to specify `a comma-separated list of topics`. Must not have spaces.
 
-  * `auto.create` - This setting allows creation of a new table in SAP DBs if the table specified in `{topic}.table.name` does not exist. Should be a `Boolean`. Default is `false`.
+  * `auto.create` - This setting allows the creation of a new table in SAP DBs if the table specified in `{topic}.table.name` does not exist. Should be a `Boolean`. Default is `false`.
+
+  * `auto.evolve` - This setting allows the evolution of the table schema with some restriction, namely when the record contains additional nullable fields that are not present previously, the corresponding columns will be added. In contrast, when the record contains less fields, the table schema will not be changed. Should be a `Boolean`. Default is `false`.
 
   * `batch.size` - This setting can be used to specify the number of records that can be pushed into SAP DB table in a single flush. Should be an `Integer`. Default is `3000`.
 

--- a/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
@@ -40,6 +40,12 @@ abstract class BaseConfig(props: Map[String, String]) {
   def autoCreate = props.getOrElse[String]("auto.create", "false").toBoolean
 
   /**
+    * Auto evolve HANA tables if table requires some changes to match the record for Sink.
+    * Default is false.
+    */
+  def autoEvolve = props.getOrElse[String]("auto.evolve", "false").toBoolean
+
+  /**
     * Max rows to include in a single batch call for source. Should be an integer.
     * Default is 100.
     */


### PR DESCRIPTION
Supporting schema evolution at the sink connector with some restriction. When `auto.evolve` property is set to "true" and the table schema will be automatically updated/altered when the record contains additional fields.

Signed-off-by: Aki Yoshida <elakito@gmail.com>