### PR TITLE
chore: Add REUSE tool information to README

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,5 +3,5 @@ Upstream-Name: Kafka Connect SAP
 Source: https://github.com/SAP/kafka-connect-sap
 
 Files: *
-Copyright: 2020 SAP SE or an SAP affiliate company and Kafka Connect SAP contributors
+Copyright: 2015-2021 SAP SE or an SAP affiliate company and kafka-connect-sap contributors
 License: Apache-2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,1 +1,0 @@
-Copyright (c) 2015-2020 SAP SE or an SAP affiliate company. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.com/SAP/kafka-connect-sap.svg?branch=master)](https://travis-ci.com/SAP/kafka-connect-sap)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/kafka-connect-sap)](https://api.reuse.software/info/github.com/SAP/kafka-connect-sap)
 
 # Kafka Connectors for SAP
 
@@ -168,8 +169,6 @@ Contributions are accepted by sending Pull Requests to this repo. Please do not 
 
 Currently only SAP Hana is supported.
 
-
 ## License
-Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
-This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE file](LICENSE).
 
+Copyright (c) 2015-2021 SAP SE or an SAP affiliate company and kafka-connect-sap contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/kafka-connect-sap).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #87 and #88)

Fixes #86 