### PR TITLE
Add guava to persons1 libs.txt

### DIFF
--- a/examples/persons1/README.md
+++ b/examples/persons1/README.md
@@ -44,7 +44,7 @@ $ make get_libs
 Getting jar files into target ...
 ...
 $ ls target
-ngdbc-2.10.14.jar
+guava-31.0.1-jre.jar  ngdbc-2.10.14.jar
 $
 ```
 

--- a/examples/persons1/libs.txt
+++ b/examples/persons1/libs.txt
@@ -1,1 +1,2 @@
+com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar
 com/sap/cloud/db/jdbc/ngdbc/2.10.14/ngdbc-2.10.14.jar


### PR DESCRIPTION
Avoid getting java.lang.NoClassDefFoundError at the sink connector in example persons1.

In some old kafka such as 2.4.1, kafka's libs folder contained a compatible guava jar. As a result, the instruction for examples persons1 didn't refer to guava. As more recent kafka releases do not contain guava, this jar must be added to the plugins folder otherwise the below error occurs.
```
[2022-01-19 18:49:04,590] ERROR WorkerSinkTask{id=test_topic_1_sink-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask:187)
java.lang.NoClassDefFoundError: com/google/common/base/Function
	at com.sap.kafka.connect.sink.hana.HANASinkTask.initWriter(HANASinkTask.scala:29)
	at com.sap.kafka.connect.sink.hana.HANASinkTask.start(HANASinkTask.scala:24)

```
This fixes #109