### PR TITLE
Improve decimal handling with numeric.mapping, precision extraction, ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ of the column can be numeric types such as `INTEGER`, `FLOAT`, `DECIMAL`, dateti
  
   * `{topic}.partition.count` - This setting can be used to specify the no. of topic partitions that the Source connector can use to publish the data. Should be an `Integer`. Default value is `1`.
 
+  * `numeric.mapping` - This setting can be used to control whether the DECIMAL column types are mapped to the default decimal type or one of the primitive types. The supported values are `none`, `best_fit`, and `best_fit_eager_double`. The default value is `none`.
+
 
 ## Examples
 

--- a/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/BaseConfig.scala
@@ -68,6 +68,12 @@ abstract class BaseConfig(props: Map[String, String]) {
     */
   def autoSchemaUpdateOn = props.getOrElse[String]("auto.schema.update", "false").toBoolean
 
+  /**
+   * Specifies how the numeric type is mapped.
+   * Default is 'none'
+   */
+  def numericMapping: String = props.getOrElse[String]("numeric.mapping", BaseConfigConstants.NUMERIC_MAPPING_NONE)
+
   def topicProperties(topic: String) = {
     val topicPropMap = scala.collection.mutable.Map[String, String]()
 

--- a/src/main/scala/com/sap/kafka/connect/config/BaseParameters.scala
+++ b/src/main/scala/com/sap/kafka/connect/config/BaseParameters.scala
@@ -28,6 +28,10 @@ object BaseConfigConstants {
 
   val IN_MEMORY_ENGINE = "in-memory"
   val DISK_ENGINE = "disk"
+
+  val NUMERIC_MAPPING_NONE = "none"
+  val NUMERIC_MAPPING_BEST_FIT = "best_fit"
+  val NUMERIC_MAPPING_BEST_FIT_EAGER_DOUBLE = "best_fit_eager_double"
 }
 
 trait BaseParameters {

--- a/src/main/scala/com/sap/kafka/connect/source/hana/HANASourceConnector.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/hana/HANASourceConnector.scala
@@ -3,7 +3,6 @@ package com.sap.kafka.connect.source.hana
 import com.sap.kafka.client.hana.{HANAConfigInvalidInputException, HANAConfigMissingException, HANAJdbcClient}
 import com.sap.kafka.connect.config.BaseConfigConstants
 import com.sap.kafka.connect.config.hana.{HANAConfig, HANAParameters}
-import com.sap.kafka.utils.ExecuteWithExceptions
 
 import java.util
 import org.apache.kafka.common.config.{ConfigDef, ConfigException}

--- a/src/main/scala/com/sap/kafka/connect/source/querier/TableQuerier.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/querier/TableQuerier.scala
@@ -80,18 +80,19 @@ abstract class TableQuerier(mode: String, tableOrQuery: String,
   }
 
   private def getSchema(): Schema = {
+    val options = Map("numeric.mapping" -> config.numericMapping)
     mode match {
       case BaseConfigConstants.QUERY_MODE_TABLE =>
         if (getOrCreateJdbcClient().get.isInstanceOf[HANAJdbcClient]) {
           val metadata = getOrCreateJdbcClient().get.getMetaData(tableOrQuery, None)
-          HANAJdbcTypeConverter.convertHANAMetadataToSchema(tableName, metadata)
+          HANAJdbcTypeConverter.convertHANAMetadataToSchema(tableName, metadata, options)
         } else {
           throw new RuntimeException("Jdbc Client is not available")
         }
       case BaseConfigConstants.QUERY_MODE_SQL =>
         if (getOrCreateJdbcClient().get.isInstanceOf[HANAJdbcClient]) {
           val metadata = getOrCreateJdbcClient().get.getMetadata(tableOrQuery)
-          HANAJdbcTypeConverter.convertHANAMetadataToSchema("Query" + Random.nextInt, metadata)
+          HANAJdbcTypeConverter.convertHANAMetadataToSchema("Query" + Random.nextInt, metadata, options)
         } else {
           throw new RuntimeException("Jdbc Client is not available")
         }

--- a/src/main/scala/com/sap/kafka/utils/GenericSchemaBuilder.scala
+++ b/src/main/scala/com/sap/kafka/utils/GenericSchemaBuilder.scala
@@ -59,7 +59,7 @@ trait GenericSchemaBuilder {
     logicalType match {
       case Date.LOGICAL_NAME => "DATE"
       case Decimal.LOGICAL_NAME =>
-        s"""DECIMAL(10, ${parameters(Decimal.SCALE_FIELD)})"""
+        s"""DECIMAL(${parameters.getOrElse("precision", "10")}, ${parameters(Decimal.SCALE_FIELD)})"""
       case Time.LOGICAL_NAME => "TIME"
       case Timestamp.LOGICAL_NAME => "TIMESTAMP"
       case _ => throw new ConnectorException(s"Field Schema type name $logicalType is invalid")

--- a/src/main/scala/com/sap/kafka/utils/hana/HANAJdbcTypeConverter.scala
+++ b/src/main/scala/com/sap/kafka/utils/hana/HANAJdbcTypeConverter.scala
@@ -19,8 +19,9 @@ object HANAJdbcTypeConverter extends GenericJdbcTypeConverter {
     * Convert HANA Table schema to Kafka Schema
     * @param tableName HANA table for which metadata is converted
     * @param datatypes sequence containing metadata for table
+    * @param options properties to influence the conversion
     * @return kafka schema
     */
-  def convertHANAMetadataToSchema(tableName: String, datatypes: Seq[metaAttr]): Schema =
-    super.convertJdbcMetadataToSchema(tableName, datatypes)
+  def convertHANAMetadataToSchema(tableName: String, datatypes: Seq[metaAttr], options: Map[String, String]): Schema =
+    super.convertJdbcMetadataToSchema(tableName, datatypes, options)
 }

--- a/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskConversionTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskConversionTest.scala
@@ -3,9 +3,10 @@ package com.sap.kafka.connect.source
 import com.sap.kafka.client.MetaSchema
 import com.sap.kafka.connect.source.hana.HANASourceConnector
 import org.apache.kafka.connect.data.Schema.Type
-import org.apache.kafka.connect.data.{Field, Schema, Struct}
+import org.apache.kafka.connect.data.{Decimal, Field, Schema, Struct}
 import org.apache.kafka.connect.source.SourceRecord
 
+import java.math.RoundingMode
 import scala.collection.JavaConverters._
 
 class HANASourceTaskConversionTest extends HANASourceTaskTestBase {
@@ -46,6 +47,12 @@ class HANASourceTaskConversionTest extends HANASourceTaskTestBase {
   test("string type") {
     typeConversion(Schema.STRING_SCHEMA, true, "'a'",
       Schema.STRING_SCHEMA, "a")
+  }
+
+  test("decimal type") {
+    val schema = Decimal.builder(2).parameter("precision", Integer.toString(10)).build()
+    typeConversion(schema, true, "3.12",
+      schema, new java.math.BigDecimal(3.12).setScale(2, RoundingMode.HALF_UP))
   }
 
   private def typeConversion(sqlType: Schema, nullable: Boolean,

--- a/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskDecimalConversionTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskDecimalConversionTest.scala
@@ -1,0 +1,75 @@
+package com.sap.kafka.connect.source
+
+import com.sap.kafka.client.MetaSchema
+import com.sap.kafka.connect.config.BaseConfigConstants
+import com.sap.kafka.connect.source.hana.HANASourceConnector
+import org.apache.kafka.connect.data.Schema.Type
+import org.apache.kafka.connect.data.{Decimal, Field, Schema, Struct}
+import org.apache.kafka.connect.source.SourceRecord
+
+import java.math.RoundingMode
+import scala.collection.JavaConverters._
+
+class HANASourceTaskDecimalConversionTest extends HANASourceTaskTestBase {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    connector = new HANASourceConnector
+    connector.start(singleTableNumericMappingConfig())
+    task.start(connector.taskConfigs(1).get(0))
+  }
+
+  override def afterAll(): Unit = {
+    task.stop()
+    connector.stop()
+    super.afterAll()
+  }
+
+  test("decimal type with numeric.mapping") {
+    val fields = Seq(
+      new Field("dec1_p10s2", 1, Decimal.builder(2).build()),
+      new Field("dec2_p10s2", 2, Decimal.builder(2).build()),
+      new Field("dec3_p10s0", 3, Decimal.builder(0).build()))
+
+    jdbcClient.createTable(Some("TEST"),"EMPLOYEES_SOURCE", MetaSchema(null, fields),
+      3000)
+    val connection = jdbcClient.getConnection
+    try {
+      connection.setAutoCommit(true)
+      val stmt = connection.createStatement()
+      stmt.execute("insert into \"TEST\".\"EMPLOYEES_SOURCE\" values(3.14, 314, 314)")
+
+      var records = task.poll()
+      if (records == null) {
+        records = task.poll()
+      }
+      assert(records.size === 1)
+      val objValue = records.get(0).value
+      assert(objValue.isInstanceOf[Struct])
+      val value = objValue.asInstanceOf[Struct]
+
+      val schema = value.schema()
+      val fields = schema.fields()
+
+      assert(fields.size() === 3)
+      validateField(0, fields, value, Schema.FLOAT64_SCHEMA, java.lang.Double.valueOf(3.14))
+      validateField(1, fields, value, Schema.FLOAT64_SCHEMA, java.lang.Double.valueOf(314))
+      validateField(2, fields, value, Schema.INT64_SCHEMA, java.lang.Long.valueOf(314))
+
+      stmt.execute("drop table \"TEST\".\"EMPLOYEES_SOURCE\"")
+    } finally {
+      connection.close()
+    }
+  }
+
+  private def validateField(index: Int, fields: java.util.List[Field], value: Struct, expectedSchema: Schema, expectedValue: Object): Unit = {
+    val field = fields.get(index)
+    assert(expectedSchema === field.schema)
+    assert(expectedValue === value.get(field))
+  }
+
+  private def singleTableNumericMappingConfig(): java.util.Map[String, String] = {
+    val config = singleTableConfig()
+    config.put("numeric.mapping", BaseConfigConstants.NUMERIC_MAPPING_BEST_FIT)
+    config
+  }
+}


### PR DESCRIPTION
Add configuration property `numeric.mapping` to be aligned with the behavior supported by the the JDBC connector.

Note that HANA DECIMAL assumes the scale value to be non-negative and the precision value to be between 1 and 34 (https://help.sap.com/viewer/7c78579ce9b14a669c1f3295b0d8ca16/LATEST/en-US/4ee2f261e9c44003807d08ccc2e249ac.html).

This will resolve #104.