### PR TITLE
Use UTC for date, time, timestamp consistently

### DIFF
--- a/src/main/scala/com/sap/kafka/connect/source/querier/IncrColTableQuerier.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/querier/IncrColTableQuerier.scala
@@ -7,7 +7,6 @@ import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.source.SourceRecord
 
 import scala.collection.JavaConverters._
-import scala.util.Random
 
 class IncrColTableQuerier(mode: String, tableOrQuery: String, tablePartition: Int, topic: String,
                           incrementingColumn: String, offsetMap: Map[String, Object],
@@ -56,8 +55,12 @@ class IncrColTableQuerier(mode: String, tableOrQuery: String, tablePartition: In
         var partition: Map[String, String] = null
 
         if (incrementingColumn != null) {
-          val id = record.get(incrementingColumn).toString
-          offset = new TimestampIncrementingOffset(id)
+          val id = record.get(incrementingColumn)
+          val idstr = id match {
+            case _: java.util.Date => TimestampIncrementingOffset.UTC_DATETIME_FORMAT.format(id)
+            case _ => id.toString
+          }
+          offset = new TimestampIncrementingOffset(idstr)
         }
 
         mode match {

--- a/src/main/scala/com/sap/kafka/connect/source/querier/TimestampIncrementingOffset.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/querier/TimestampIncrementingOffset.scala
@@ -1,9 +1,10 @@
 package com.sap.kafka.connect.source.querier
 
 import java.util
-
 import com.sap.kafka.client.hana.HANAConfigMissingException
 import com.sap.kafka.utils.ExecuteWithExceptions
+
+import java.text.SimpleDateFormat
 
 class TimestampIncrementingOffset(incrementingOffset: String) {
   def getIncrementingOffset(): String = {
@@ -24,6 +25,12 @@ class TimestampIncrementingOffset(incrementingOffset: String) {
 
 object TimestampIncrementingOffset {
   var INCREMENTING_FIELD: String = _
+
+  import java.text.SimpleDateFormat
+  import java.util.TimeZone
+
+  val UTC_DATETIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+  UTC_DATETIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"))
 
   private val DEFAULT_DATE = "1970-01-01 00:00:00.000"
   private val DEFAULT_VAL = "-1"

--- a/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
+++ b/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
@@ -182,17 +182,17 @@ trait GenericJdbcTypeConverter {
         val dateSchemaBuilder = Date.builder()
         if (optional)
           dateSchemaBuilder.optional()
-        builder.field(fieldname, dateSchemaBuilder)
+        builder.field(fieldname, dateSchemaBuilder.build())
       case java.sql.Types.TIME =>
         val timeSchemaBuilder = Time.builder()
         if (optional)
           timeSchemaBuilder.optional()
-        builder.field(fieldname, timeSchemaBuilder)
+        builder.field(fieldname, timeSchemaBuilder.build())
       case java.sql.Types.TIMESTAMP =>
         val tsSchemaBuilder = Timestamp.builder()
         if (optional)
           tsSchemaBuilder.optional()
-        builder.field(fieldname, tsSchemaBuilder)
+        builder.field(fieldname, tsSchemaBuilder.build())
       case java.sql.Types.ARRAY | java.sql.Types.JAVA_OBJECT | java.sql.Types.OTHER |
            java.sql.Types.DISTINCT | java.sql.Types.STRUCT | java.sql.Types.REF |
            java.sql.Types.ROWID =>

--- a/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
+++ b/src/main/scala/com/sap/kafka/utils/GenericJdbcTypeConverter.scala
@@ -7,8 +7,12 @@ import com.sap.kafka.connect.config.BaseConfigConstants
 import org.apache.kafka.connect.data._
 import org.slf4j.LoggerFactory
 
+import java.util.{Calendar, TimeZone}
+
 trait GenericJdbcTypeConverter {
   private val log = LoggerFactory.getLogger(getClass)
+
+  private val calendarUTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
 
   /**
     * Converts a Kafka SinkRow Schema  to the most compatible Jdbc SQL datatype.
@@ -80,9 +84,9 @@ trait GenericJdbcTypeConverter {
     case java.sql.Types.BINARY | java.sql.Types.BLOB | java.sql.Types.VARBINARY |
          java.sql.Types.LONGVARBINARY => (value: Any)  =>
       stmt.setBytes(i + 1, value.asInstanceOf[Array[Byte]])
-    case java.sql.Types.DATE => (value: Any) => stmt.setDate(i + 1, convertToJdbcDateTypeFromAvroDateType(value))
-    case java.sql.Types.TIME => (value: Any) => stmt.setTime(i + 1, convertToJdbcTimeTypeFromAvroTimeType(value))
-    case java.sql.Types.TIMESTAMP => (value: Any) => stmt.setTimestamp(i + 1, convertToJdbcTimestampTypeFromAvroTimestampType(value))
+    case java.sql.Types.DATE => (value: Any) => stmt.setDate(i + 1, convertToJdbcDateTypeFromAvroDateType(value), calendarUTC)
+    case java.sql.Types.TIME => (value: Any) => stmt.setTime(i + 1, convertToJdbcTimeTypeFromAvroTimeType(value), calendarUTC)
+    case java.sql.Types.TIMESTAMP => (value: Any) => stmt.setTimestamp(i + 1, convertToJdbcTimestampTypeFromAvroTimestampType(value), calendarUTC)
     case other =>
       (value: Any) =>
         sys.error(s"Unable to translate the non-null value for the field $i")

--- a/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
@@ -3,8 +3,7 @@ package com.sap.kafka.connect.sink
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util
-import java.util.TimeZone
-
+import java.util.{Calendar, TimeZone}
 import com.sap.kafka.connect.MockJdbcClient
 import com.sap.kafka.connect.config.hana.HANAParameters
 import com.sap.kafka.connect.sink.hana.HANASinkTask
@@ -17,6 +16,8 @@ import scala.math.BigDecimal.RoundingMode
 
 class AvroLogicalTypesTest extends FunSuite {
   val TEST_CONNECTION_URL = "jdbc:h2:mem:test;INIT=CREATE SCHEMA IF NOT EXISTS TEST"
+
+  private val calendarUTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
 
   test("put propagates to DB with schema containing date fields") {
     val schema = SchemaBuilder.struct()
@@ -53,6 +54,7 @@ class AvroLogicalTypesTest extends FunSuite {
     //  }
     // }
     val simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd")
+    simpleDateFormat.setCalendar(calendarUTC)
     val expectedDateField = "2013-10-16"
     val date = simpleDateFormat.parse(expectedDateField)
 
@@ -147,6 +149,7 @@ class AvroLogicalTypesTest extends FunSuite {
     //  }
     // }
     val simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss'Z'")
+    simpleDateFormat.setCalendar(calendarUTC)
     val expectedDateField = "2013-10-16T02:02:02Z"
     val expectedTimeField = "02:02:02"
     val date = simpleDateFormat.parse(expectedDateField)
@@ -203,6 +206,7 @@ class AvroLogicalTypesTest extends FunSuite {
     //  }
     // }
     val simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'")
+    simpleDateFormat.setCalendar(calendarUTC)
     val expectedDateField = "2013-10-16T02:02:02.002Z"
     val expectedTimestampField = "2013-10-16 02:02:02.002"
     val date = simpleDateFormat.parse(expectedDateField)

--- a/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskTestBase.scala
+++ b/src/test/scala/com/sap/kafka/connect/source/HANASourceTaskTestBase.scala
@@ -14,6 +14,8 @@ import org.mockito.Mockito._
 import org.apache.kafka.connect.data.{Field, Schema}
 import org.mockito.ArgumentMatchers.any
 
+import java.text.SimpleDateFormat
+
 class HANASourceTaskTestBase extends FunSuite
                               with BeforeAndAfterAll {
   val tmpdir = System.getProperty("java.io.tmpdir")
@@ -25,6 +27,7 @@ class HANASourceTaskTestBase extends FunSuite
 
   protected val SINGLE_TABLE_NAME_FOR_INCR_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_INCR_LOAD\""
   protected val SINGLE_TABLE_NAME_FOR_INCR2_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_INCR2_LOAD\""
+  protected val SINGLE_TABLE_NAME_FOR_INCR3_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_INCR3_LOAD\""
   protected val SINGLE_TABLE_NAME_FOR_INCR_QUERY_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_FOR_INCR_QUERY_LOAD\""
   protected val SINGLE_TABLE_NAME_FOR_INCR_MAXROWS_LOAD = "\"TEST\".\"EMPLOYEES_SOURCE_MAXROWS_FOR_INCR_LOAD\""
 
@@ -43,6 +46,8 @@ class HANASourceTaskTestBase extends FunSuite
   SINGLE_TABLE_PARTITION_FOR_INCR_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_INCR_LOAD + PARTION_SUFFIX)
   protected val SINGLE_TABLE_PARTITION_FOR_INCR2_LOAD = new util.HashMap[String, String]()
   SINGLE_TABLE_PARTITION_FOR_INCR2_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_INCR2_LOAD + PARTION_SUFFIX)
+  protected val SINGLE_TABLE_PARTITION_FOR_INCR3_LOAD = new util.HashMap[String, String]()
+  SINGLE_TABLE_PARTITION_FOR_INCR3_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_INCR3_LOAD + PARTION_SUFFIX)
   protected val SINGLE_TABLE_PARTITION_FOR_INCR_QUERY_LOAD = new util.HashMap[String, String]()
   SINGLE_TABLE_PARTITION_FOR_INCR_QUERY_LOAD.put(SourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME_FOR_INCR_QUERY_LOAD + PARTION_SUFFIX)
   protected val SINGLE_TABLE_PARTITION_FOR_INCR_MAXROWS_LOAD = new util.HashMap[String, String]()


### PR DESCRIPTION
Inserting date time related values that correspond to the UTC values without specifying the UTC calendar will store the values converted to the local values. This will cause the values later retrieved as UTC to be incorrect.
To avoid this problem, use UTC for both storing and retrieving the date time related values.

This will fix #121.