### PR TITLE
Add a generic field name escape transformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <version>${kafka.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <version>${kafka.version}</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- misc dependencies -->
         <dependency>

--- a/src/main/scala/com/sap/kafka/connect/transforms/EscapeFieldNameCharacters.scala
+++ b/src/main/scala/com/sap/kafka/connect/transforms/EscapeFieldNameCharacters.scala
@@ -1,0 +1,196 @@
+package com.sap.kafka.connect.transforms
+
+import org.apache.kafka.common.cache.{Cache, LRUCache, SynchronizedCache}
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.connect.connector.ConnectRecord
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.transforms.Transformation
+import org.apache.kafka.connect.transforms.util.Requirements.{requireMap, requireStruct}
+import org.apache.kafka.connect.transforms.util.{SchemaUtil, SimpleConfig}
+import org.slf4j.LoggerFactory
+
+import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util
+import scala.util.matching.Regex
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuilder
+
+abstract class EscapeFieldNameCharacters[R <: ConnectRecord[R]] extends Transformation[R] {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  private var validCharRE: Regex = _
+  private var validFirstCharRE: Regex = _
+  private var escChar: Char = _
+
+  private var schemaUpdateCache: Cache[Schema, Schema] = _
+
+  override def configure(props: util.Map[String, _]): Unit = {
+    val config = new SimpleConfig(EscapeFieldNameCharacters.CONFIG_DEF, props)
+    val validCharPattern = config.getString(EscapeFieldNameCharacters.CONFIG_VALID_CHARS_DEFAULT)
+    if (validCharPattern != null && validCharPattern.length > 0) {
+      validCharRE = validCharPattern.r
+    }
+    val validFirstCharPattern = config.getString(EscapeFieldNameCharacters.CONFIG_VALID_CHARS_FIRST)
+    if (validFirstCharPattern != null && validFirstCharPattern.length > 0) {
+      validFirstCharRE = validFirstCharPattern.r
+    } else {
+      validFirstCharRE = validCharRE
+    }
+    escChar = config.getString(EscapeFieldNameCharacters.CONFIG_ESCAPE_CHAR)(0)
+
+    schemaUpdateCache = new SynchronizedCache[Schema, Schema](new LRUCache[Schema, Schema](16))
+  }
+
+  override def apply(record: R): R = {
+    if (operatingValue(record) == null) {
+      record
+    } else if (operatingSchema(record) == null) {
+      applySchemaless(record)
+    } else {
+      applyWithSchema(record)
+    }
+  }
+
+  private def applySchemaless(record: R): R = {
+    val value = requireMap(operatingValue(record), EscapeFieldNameCharacters.PURPOSE)
+    val updatedValue = new util.HashMap[String, Object](value.size)
+    for (e <- value.entrySet.asScala) {
+      updatedValue.put(if (validCharRE == null) decode(e.getKey) else encode(e.getKey), e.getValue)
+    }
+    newRecord(record, null, updatedValue)
+  }
+
+  private def applyWithSchema(record: R): R = {
+    val value = requireStruct(operatingValue(record), EscapeFieldNameCharacters.PURPOSE)
+    var updatedSchema = schemaUpdateCache.get(value.schema)
+    if (updatedSchema == null) {
+      updatedSchema = makeUpdatedSchema(value.schema)
+      schemaUpdateCache.put(value.schema, updatedSchema)
+    }
+    var updatedValue = new Struct(updatedSchema)
+    var origFieldIt = value.schema.fields().iterator
+    for (field <- updatedSchema.fields.asScala) {
+      updatedValue.put(field.name, value.get(origFieldIt.next))
+    }
+    newRecord(record, updatedSchema, updatedValue)
+  }
+
+  private def makeUpdatedSchema(schema: Schema): Schema = {
+    val builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct())
+    for (field <- schema.fields.asScala) {
+      builder.field(if (validCharRE == null) decode(field.name) else encode(field.name) , field.schema)
+    }
+    builder.build
+  }
+
+  private def encode(value: String): String = {
+    val buf = new StringBuilder
+    var escaped = false
+    for (i <- 0 to value.length - 1) {
+      val re = i match {
+        case 0 => validFirstCharRE
+        case _ => validCharRE
+      }
+      val c = value.substring(i, i+1)
+      if (value.charAt(i) != escChar && re.findFirstIn(c) != None) {
+        buf.append(c)
+      } else {
+        for (b <- c.getBytes(UTF_8)) {
+          buf.append(f"$escChar%c$b%x")
+        }
+        escaped = true
+      }
+    }
+    escaped match {
+      case true => buf.toString
+      case _ => value
+    }
+  }
+
+  private def decode(value: String): String = {
+    val buf = new StringBuilder
+    val bdec = new ArrayBuilder.ofByte
+    var bdeclen = 0
+    if (value.contains(escChar)) {
+      var i = 0
+      while (i < value.length) {
+        val c = value.charAt(i)
+        if (c == escChar) {
+          bdec += Integer.parseInt(value.substring(i + 1, i + 3), 16).toByte
+          bdeclen += 1
+          i += 2
+        } else {
+          if (bdeclen > 0) {
+            buf.append(new String(bdec.result, StandardCharsets.UTF_8))
+            bdec.clear
+            bdeclen = 0
+          }
+          buf.append(c)
+        }
+        i += 1
+      }
+      buf.toString
+    } else {
+      value
+    }
+  }
+
+  override def close(): Unit = {
+    validCharRE = null
+    validFirstCharRE = null
+    schemaUpdateCache = null
+  }
+
+  override def config() = EscapeFieldNameCharacters.CONFIG_DEF
+
+  protected def operatingSchema(record: R): Schema
+
+  protected def operatingValue(record: R): Any
+
+  protected def newRecord(record: R, updatedSchema: Schema, updatedValue: Any): R
+}
+
+object EscapeFieldNameCharacters {
+  private val CONFIG_VALID_CHARS_DEFAULT = "valid.chars.default"
+  private val CONFIG_VALID_CHARS_FIRST = "valid.chars.first"
+  private val CONFIG_ESCAPE_CHAR = "escape.char"
+
+  val OVERVIEW_DOC = s"Escaping specific characters from the field names."
+  val CONFIG_DEF = new ConfigDef()
+    .define(CONFIG_VALID_CHARS_DEFAULT, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
+      "Field name for valid characters pattern")
+    .define(CONFIG_VALID_CHARS_FIRST, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
+      "Field name for valid first characters pattern")
+    .define(CONFIG_ESCAPE_CHAR, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
+      "Field name for escape character")
+  private val PURPOSE = "field replacement"
+
+  class Key[R <: ConnectRecord[R]] extends EscapeFieldNameCharacters[R] {
+    override protected def operatingSchema(record: R): Schema = {
+      record.keySchema
+    }
+
+    override protected def operatingValue(record: R): Any = {
+      record.key
+    }
+
+    override protected def newRecord(record: R, updatedSchema: Schema, updatedValue: Any): R = {
+      record.newRecord(record.topic, record.kafkaPartition, updatedSchema, updatedValue, record.valueSchema, record.value, record.timestamp)
+    }
+  }
+
+  class Value[R <: ConnectRecord[R]] extends EscapeFieldNameCharacters[R] {
+    override protected def operatingSchema(record: R): Schema = {
+      record.valueSchema
+    }
+
+    override protected def operatingValue(record: R): Any = {
+      record.value
+    }
+
+    override protected def newRecord(record: R, updatedSchema: Schema, updatedValue: Any): R = {
+      record.newRecord(record.topic, record.kafkaPartition, record.keySchema, record.key, updatedSchema, updatedValue, record.timestamp)
+    }
+  }
+}

--- a/src/test/scala/com/sap/kafka/connect/transforms/EscapeFieldNameCharactersTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/transforms/EscapeFieldNameCharactersTest.scala
@@ -1,0 +1,73 @@
+package com.sap.kafka.connect.transforms
+
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.source.SourceRecord
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+
+import java.util
+
+class EscapeFieldNameCharactersTest extends FunSuite with BeforeAndAfterEach {
+  val xform = new EscapeFieldNameCharacters.Value[SourceRecord]
+
+  override protected def afterEach(): Unit = {
+    xform.close()
+  }
+
+  test("escape chars for avro") {
+    val props = new util.HashMap[String, Object]()
+    props.put("valid.chars.default", "[A-Za-z0-9_]")
+    props.put("valid.chars.first", "[A-Za-z_]")
+    props.put("escape.char", "_")
+
+    xform.configure(props)
+    val valueSchema = SchemaBuilder.struct()
+      .name("schema with unwanted field names")
+      .field("id", Schema.INT32_SCHEMA)
+      .field("x/field", Schema.STRING_SCHEMA)
+      .field("123", Schema.STRING_SCHEMA).build()
+    val value = new Struct(valueSchema)
+      .put("id", 23)
+      .put("x/field", "xy")
+      .put("123", "0307")
+    val rec = new SourceRecord(null, null, "test", 0, valueSchema, value)
+    val recout = xform.apply(rec)
+
+    val recoutValue = recout.value.asInstanceOf[Struct]
+    assert(recoutValue.getInt32("id") === 23)
+    assert(recoutValue.getString("x_2ffield") === "xy")
+    assert(recoutValue.getString("_3123") === "0307")
+
+    val recoutSchema = recout.valueSchema
+    assert(recoutSchema.field("id").index === 0)
+    assert(recoutSchema.field("x_2ffield").index === 1)
+    assert(recoutSchema.field("_3123").index === 2)
+  }
+
+  test("unescape chars for avro") {
+    val props = new util.HashMap[String, Object]()
+    props.put("escape.char", "_")
+
+    xform.configure(props)
+    val valueSchema = SchemaBuilder.struct()
+      .name("schema with unwanted field names")
+      .field("id", Schema.INT32_SCHEMA)
+      .field("x_2ffield", Schema.STRING_SCHEMA)
+      .field("_3123", Schema.STRING_SCHEMA).build()
+    val value = new Struct(valueSchema)
+      .put("id", 23)
+      .put("x_2ffield", "xy")
+      .put("_3123", "0307")
+    val rec = new SourceRecord(null, null, "test", 0, valueSchema, value)
+    val recout = xform.apply(rec)
+
+    val recoutValue = recout.value.asInstanceOf[Struct]
+    assert(recoutValue.getInt32("id") === 23)
+    assert(recoutValue.getString("x/field") === "xy")
+    assert(recoutValue.getString("123") === "0307")
+
+    val recoutSchema = recout.valueSchema
+    assert(recoutSchema.field("id").index === 0)
+    assert(recoutSchema.field("x/field").index === 1)
+    assert(recoutSchema.field("123").index === 2)
+  }
+}


### PR DESCRIPTION
This is a utility SMT to transform HANA column names that do not fit to the avro field naming scheme.

The escape encoding scheme is similar to that of URLEncoding where each character not belonging to the valid character set will be replaced with its UTF-8 byte sequence `<esc><xx>`, where `<esc>` is the specified the escape character and `<xx>` is the hexadecimal representation of its value.

For example, to encode arbitrary field names into valid avro names, add this transformer with the following setting at the source connector.

```
        "transforms": "escapeChars",
        "transforms.escapeChars.type": "com.sap.kafka.connect.transforms.EscapeFieldNameCharacters$Value",
        "transforms.escapeChars.valid.chars.default": "[A-Za-z0-9_]",
        "transforms.escapeChars.valid.chars.first": "[A-Za-z_]",
        "transforms.escapeChars.escape.char": "_",
```

To revert the field names back to the original field names, add this transformer with the following setting at the sink connector.
```
        "transforms": "escapeChars",
        "transforms.escapeChars.type": "com.sap.kafka.connect.transforms.EscapeFieldNameCharacters$Value",
        "transforms.escapeChars.escape.char": "_",
```

This transformer maybe be used to solve problems mentioned in #126.