### PR TITLE
Fix test failing on time conversion

### DIFF
--- a/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
+++ b/src/test/scala/com/sap/kafka/connect/sink/AvroLogicalTypesTest.scala
@@ -71,7 +71,7 @@ class AvroLogicalTypesTest extends FunSuite {
     assert(structs.size === 1)
     val head = structs.head
 
-    val actualDateField = head.get("date_field").toString
+    val actualDateField = simpleDateFormat.format(head.get("date_field"))
     assert(expectedDateField === actualDateField)
   }
 


### PR DESCRIPTION
One of the tests was failing when executed in the PST timezone due to time zone conversion. 

When executing this command:
```
mvn test -Dsuites="com.sap.kafka.connect.sink.AvroLogicalTypesTest @put propagates to DB with schema containing date fields"
```

The test has failed with this message:
```
[INFO] --- scalatest-maven-plugin:1.0:test (test) @ kafka-connector-hana_2.12 ---
Run starting. Expected test count is: 1
AvroLogicalTypesTest:
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANASinkTask - Starting Kafka-Connect task
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANASinkTask - init HANA Writer for writing the records
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANASinkTask - init HANA Writer for writing the records
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANASinkTask - PHASE - 1 - get records from kafka, Started for task with assigned partitions []
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANASinkTask - Number of Records read for Sink: 1
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANAWriter - write records to HANA
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANAWriter - initialize connection to HANA
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.client.hana.HANAJdbcClient - Creating table:DATE_TABLE with SQL: CREATE TABLE "TEST"."DATE_TABLE" ("date_field" DATE NOT NULL, PRIMARY KEY ("date_field"))
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANAWriter - flush records into HANA
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.client.hana.AbstractHANAPartitionLoader - Creating prepared statement: INSERT INTO "TEST"."DATE_TABLE" ("date_field") VALUES (?)
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANAWriter - flushing records to HANA successful
[ScalaTest-main-running-AvroLogicalTypesTest] INFO com.sap.kafka.connect.sink.hana.HANASinkTask - PHASE - 1 ended for task, with assigned partitions []
- put propagates to DB with schema containing date fields *** FAILED ***
  "2013-10-1[6]" did not equal "2013-10-1[5]" (AvroLogicalTypesTest.scala:75)
  Analysis:
  "2013-10-1[6]" -> "2013-10-1[5]"
Run completed in 899 milliseconds.
Total number of tests run: 1
Suites: completed 1, aborted 0
Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
*** 1 TEST FAILED ***
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connector-hana 0.9.5-SNAPSHOT:
[INFO]
[INFO] kafka-connector-hana ............................... SUCCESS [  0.973 s]
[INFO] kafka-connector-hana_2.12 .......................... FAILURE [  2.762 s]
[INFO] kafka-connector-hana_2.13 .......................... SKIPPED
[INFO] kafka-connector-hana-examples ...................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.835 s
[INFO] Finished at: 2023-01-31T13:47:18-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.scalatest:scalatest-maven-plugin:1.0:test (test) on project kafka-connector-hana_2.12: There are test failures -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :kafka-connector-hana_2.12
```

**Fix**: convert `Date` value to `String` using `Calendar` before asserting it instead of calling `toString` on the date object. This is the same approach taken for similar tests for `time` and `timestamp` values in this test suite.