### PR TITLE
eliminate random int on schema creation (fallback to topic…

### DIFF
--- a/src/main/scala/com/sap/kafka/connect/source/querier/TableQuerier.scala
+++ b/src/main/scala/com/sap/kafka/connect/source/querier/TableQuerier.scala
@@ -1,14 +1,12 @@
 package com.sap.kafka.connect.source.querier
 
 import com.sap.kafka.client.hana.HANAJdbcClient
-import com.sap.kafka.connect.config.{BaseConfig, BaseConfigConstants}
 import com.sap.kafka.connect.config.hana.HANAConfig
+import com.sap.kafka.connect.config.{BaseConfig, BaseConfigConstants}
 import com.sap.kafka.utils.hana.HANAJdbcTypeConverter
 import org.apache.kafka.connect.data.{Schema, Struct}
 import org.apache.kafka.connect.source.SourceRecord
 import org.slf4j.LoggerFactory
-
-import scala.util.Random
 
 abstract class TableQuerier(mode: String, tableOrQuery: String,
                             topic: String, config: BaseConfig,
@@ -92,7 +90,7 @@ abstract class TableQuerier(mode: String, tableOrQuery: String,
       case BaseConfigConstants.QUERY_MODE_SQL =>
         if (getOrCreateJdbcClient().get.isInstanceOf[HANAJdbcClient]) {
           val metadata = getOrCreateJdbcClient().get.getMetadata(tableOrQuery)
-          HANAJdbcTypeConverter.convertHANAMetadataToSchema("Query" + Random.nextInt, metadata, options)
+          HANAJdbcTypeConverter.convertHANAMetadataToSchema(topic, metadata, options)
         } else {
           throw new RuntimeException("Jdbc Client is not available")
         }


### PR DESCRIPTION
This pull request will resolve issue #145 

Instead of randomly set a schema name on every query, just take the name of the topic which. This will fix the following behaviors:

* Schema name correspond with topic name.
* will prevent schema topic overwrite when user start a sync with a different topic
* will prevent error on too much schema versions created

This pull request was already tested on a real HANA database and everything was fine.
